### PR TITLE
nick: Add in Auth0 Dependencies to project 

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -14,6 +14,10 @@ object Dependencies {
         const val crashes = "com.microsoft.appcenter:appcenter-crashes:${Versions.Dependencies.AppCenter.core}"
     }
 
+    object Auth0 {
+        const val core = "com.auth0.android:auth0:${Versions.Dependencies.Auth0.core}"
+    }
+
     object Coil {
         const val core = "io.coil-kt:coil:${Versions.Dependencies.Coil.core}"
     }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -20,6 +20,10 @@ object Versions {
             const val core = "4.3.1"
         }
 
+        object Auth0 {
+            const val core = "2.+"
+        }
+
         object Coil { const val core = "2.2.2" }
 
         object Compose {


### PR DESCRIPTION
### Trello
https://trello.com/c/ZokvOkvr/45-add-in-auth0-support-on-the-web-side

### Issues
- In order to use auth0 for authentication of a user, we need to add the dependency  into said project. This will be used along side Firebase, in order to setup user sign along with there actual data. 

### Proposed Changes
- Add said dependency 

### TO-DO
- Create a auth0 helper module for auth 0 functionality. 
- Firebase additional deps being added and functionality. 