### PR TITLE
nick: Create UI around Create Account View

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,6 +90,7 @@ dependencies {
     api(project(path = ":app-center"))
     api(project(path = ":base-resources"))
     api(project(path = ":build-type"))
+    api(project(path = ":feature:create-account"))
     api(project(path = ":feature:forgot-password"))
     api(project(path = ":feature:home"))
     api(project(path = ":feature:login"))

--- a/app/src/main/java/com/nicholas/rutherford/track/my/shot/AppModule.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/my/shot/AppModule.kt
@@ -4,6 +4,9 @@ import com.nicholas.rutherford.track.my.shot.app.center.AppCenter
 import com.nicholas.rutherford.track.my.shot.app.center.AppCenterImpl
 import com.nicholas.rutherford.track.my.shot.build.type.BuildType
 import com.nicholas.rutherford.track.my.shot.build.type.BuildTypeImpl
+import com.nicholas.rutherford.track.my.shot.feature.create.account.CreateAccountNavigation
+import com.nicholas.rutherford.track.my.shot.feature.create.account.CreateAccountNavigationImpl
+import com.nicholas.rutherford.track.my.shot.feature.create.account.CreateAccountViewModel
 import com.nicholas.rutherford.track.my.shot.feature.forgot.password.ForgotPasswordNavigation
 import com.nicholas.rutherford.track.my.shot.feature.forgot.password.ForgotPasswordNavigationImpl
 import com.nicholas.rutherford.track.my.shot.feature.forgot.password.ForgotPasswordViewModel
@@ -41,6 +44,9 @@ class AppModule {
         single<ForgotPasswordNavigation> {
             ForgotPasswordNavigationImpl(navigator = get())
         }
+        single<CreateAccountNavigation> {
+            CreateAccountNavigationImpl(navigator = get())
+        }
         viewModel {
             MainActivityViewModel(appCenter = get())
         }
@@ -55,6 +61,9 @@ class AppModule {
         }
         viewModel {
             ForgotPasswordViewModel(navigation = get())
+        }
+        viewModel {
+            CreateAccountViewModel(navigation = get())
         }
     }
 }

--- a/app/src/main/java/com/nicholas/rutherford/track/my/shot/MainActivity.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/my/shot/MainActivity.kt
@@ -29,7 +29,8 @@ class MainActivity : ComponentActivity() {
                 loginContent = { LoginScreen(viewModel = getViewModel()) },
                 homeContent = { HomeScreen(viewModel = getViewModel()) },
                 forgotPasswordContent = { ForgotPasswordScreen(viewModel = getViewModel()) },
-                createAccountContent = { CreateAccountScreen(viewModel = getViewModel()) })
+                createAccountContent = { CreateAccountScreen(viewModel = getViewModel()) }
+            )
         }
     }
 }

--- a/app/src/main/java/com/nicholas/rutherford/track/my/shot/MainActivity.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/my/shot/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.navigation.compose.rememberNavController
+import com.nicholas.rutherford.track.my.shot.feature.create.account.CreateAccountScreen
 import com.nicholas.rutherford.track.my.shot.feature.forgot.password.ForgotPasswordScreen
 import com.nicholas.rutherford.track.my.shot.feature.home.HomeScreen
 import com.nicholas.rutherford.track.my.shot.feature.login.LoginScreen
@@ -27,7 +28,8 @@ class MainActivity : ComponentActivity() {
                 splashContent = { SplashScreen(viewModel = getViewModel()) },
                 loginContent = { LoginScreen(viewModel = getViewModel()) },
                 homeContent = { HomeScreen(viewModel = getViewModel()) },
-                forgotPasswordContent = { ForgotPasswordScreen(viewModel = getViewModel()) }
+                forgotPasswordContent = { ForgotPasswordScreen(viewModel = getViewModel()) },
+                createAccountContent = { CreateAccountScreen(viewModel = getViewModel())}
             )
         }
     }

--- a/app/src/main/java/com/nicholas/rutherford/track/my/shot/MainActivity.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/my/shot/MainActivity.kt
@@ -29,8 +29,7 @@ class MainActivity : ComponentActivity() {
                 loginContent = { LoginScreen(viewModel = getViewModel()) },
                 homeContent = { HomeScreen(viewModel = getViewModel()) },
                 forgotPasswordContent = { ForgotPasswordScreen(viewModel = getViewModel()) },
-                createAccountContent = { CreateAccountScreen(viewModel = getViewModel())}
-            )
+                createAccountContent = { CreateAccountScreen(viewModel = getViewModel()) })
         }
     }
 }

--- a/base-resources/src/main/java/com/nicholas/rutherford/track/my/shot/feature/splash/StringsIds.kt
+++ b/base-resources/src/main/java/com/nicholas/rutherford/track/my/shot/feature/splash/StringsIds.kt
@@ -3,6 +3,7 @@ package com.nicholas.rutherford.track.my.shot.feature.splash
 import com.nicholas.rutherford.track.my.shot.base.resources.R
 
 object StringsIds {
+    val allFieldsAreRequired = R.string.all_fields_are_required
     val clickMeToCreateAccount = R.string.click_me_to_create_account
     val createAccount = R.string.create_account
     val forgotPassword = R.string.forgot_password
@@ -14,4 +15,5 @@ object StringsIds {
     val proceedWithYourAccount = R.string.proceed_with_your_account
     val resetPassword = R.string.reset_password
     val splashIconDescription = R.string.splash_icon_description
+    val userName = R.string.username
 }

--- a/base-resources/src/main/java/com/nicholas/rutherford/track/my/shot/feature/splash/StringsIds.kt
+++ b/base-resources/src/main/java/com/nicholas/rutherford/track/my/shot/feature/splash/StringsIds.kt
@@ -4,6 +4,7 @@ import com.nicholas.rutherford.track.my.shot.base.resources.R
 
 object StringsIds {
     val clickMeToCreateAccount = R.string.click_me_to_create_account
+    val createAccount = R.string.create_account
     val forgotPassword = R.string.forgot_password
     val empty = R.string.empty
     val email = R.string.email

--- a/base-resources/src/main/res/values/strings.xml
+++ b/base-resources/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="all_fields_are_required">All Fields Are Required</string>
     <string name="click_me_to_create_account">Click me to create account</string>
     <string name="create_account">Create Account</string>
     <string name="forgot_password">Forgot Password</string>
@@ -11,4 +12,5 @@
     <string name="password">Password</string>
     <string name="proceed_with_your_account">Proceed With Your Account</string>
     <string name="splash_icon_description">This is a splash image for the splash screen that gets displayed before app is triggered</string>
+    <string name="username">Username</string>
 </resources>

--- a/base-resources/src/main/res/values/strings.xml
+++ b/base-resources/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="click_me_to_create_account">Click me to create account</string>
+    <string name="create_account">Create Account</string>
     <string name="forgot_password">Forgot Password</string>
     <string name="empty" translatable="false" />
     <string name="email">Email</string>

--- a/feature/create-account/build.gradle.kts
+++ b/feature/create-account/build.gradle.kts
@@ -72,4 +72,12 @@ dependencies {
 
     implementation(Dependencies.Compose.material)
     implementation(Dependencies.Compose.viewModel)
+
+    testImplementation(Dependencies.Junit.Jupiter.api)
+    testImplementation(Dependencies.Junit.Jupiter.params)
+    testImplementation(Dependencies.Junit.junit)
+
+    testImplementation(Dependencies.Mockk.core)
+
+    testRuntimeOnly(Dependencies.Junit.Jupiter.engine)
 }

--- a/feature/create-account/build.gradle.kts
+++ b/feature/create-account/build.gradle.kts
@@ -8,6 +8,14 @@ android {
     buildToolsVersion = ConfigurationData.buildToolsVersion
     compileSdk = ConfigurationData.compileSdk
 
+    buildFeatures {
+        compose = ComposeData.Enabled.value
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = ComposeData.KotlinCompiler.extensionVersion
+    }
+
     compileOptions {
         sourceCompatibility = types.BuildTypes.CompileOptions.sourceCompatibility
         targetCompatibility = types.BuildTypes.CompileOptions.targetCompatibility
@@ -57,4 +65,11 @@ android {
     }
 }
 
-dependencies {}
+dependencies {
+    api(project(path = ":base-resources"))
+    api(project(path = ":helper:ui"))
+    api(project(path = ":navigation"))
+
+    implementation(Dependencies.Compose.material)
+    implementation(Dependencies.Compose.viewModel)
+}

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountNavigation.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountNavigation.kt
@@ -1,0 +1,5 @@
+package com.nicholas.rutherford.track.my.shot.feature.create.account
+
+interface CreateAccountNavigation {
+    fun pop()
+}

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountNavigationImpl.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountNavigationImpl.kt
@@ -1,9 +1,8 @@
-package com.nicholas.rutherford.track.my.shot.feature.forgot.password
+package com.nicholas.rutherford.track.my.shot.feature.create.account
 
 import com.nicholas.rutherford.track.my.shot.navigation.NavigationDestinations
 import com.nicholas.rutherford.track.my.shot.navigation.Navigator
 
-class ForgotPasswordNavigationImpl(private val navigator: Navigator) : ForgotPasswordNavigation {
-
+class CreateAccountNavigationImpl(private val navigator: Navigator) : CreateAccountNavigation {
     override fun pop() = navigator.pop(popRouteAction = NavigationDestinations.LOGIN_SCREEN)
 }

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountScreen.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountScreen.kt
@@ -2,19 +2,25 @@ package com.nicholas.rutherford.track.my.shot.feature.create.account
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
+import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import com.nicholas.rutherford.track.my.shot.feature.splash.Colors
 import com.nicholas.rutherford.track.my.shot.feature.splash.StringsIds
 import com.nicholas.rutherford.track.my.shot.helper.ui.Padding
+import com.nicholas.rutherford.track.my.shot.helper.ui.TextStyles
 
 @Composable
 fun CreateAccountScreen(viewModel: CreateAccountViewModel) {
@@ -35,9 +41,95 @@ fun CreateAccountScreen(viewModel: CreateAccountViewModel) {
 
         Spacer(modifier = Modifier.height(Padding.eight))
 
-        Column(modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(Padding.twenty)) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(Padding.twenty)
+        ) {
+
             Text(
-                text = "Enter All Fields To Create Account"
+                text = stringResource(id = StringsIds.allFieldsAreRequired),
+                style = TextStyles.small
+            )
+
+            Spacer(modifier = Modifier.height(Padding.four))
+
+            BoxWithConstraints(
+                modifier = Modifier.clipToBounds()
+            ) {
+                TextField(
+                    label = { Text(text = stringResource(id = StringsIds.userName)) },
+                    modifier = Modifier
+                        .requiredWidth(maxWidth + Padding.sixteen)
+                        .offset(x = (-8).dp)
+                        .fillMaxWidth(),
+                    value = state.username ?: stringResource(id = StringsIds.empty),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+                    onValueChange = { newUsername -> viewModel.onUsernameValueChanged(newUsername = newUsername) },
+                    textStyle = TextStyles.body,
+                    singleLine = true,
+                    colors = TextFieldDefaults.textFieldColors(backgroundColor = Colors.whiteColor)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(Padding.four))
+
+            BoxWithConstraints(
+                modifier = Modifier.clipToBounds()
+            ) {
+                TextField(
+                    label = { Text(text = stringResource(id = StringsIds.email)) },
+                    modifier = Modifier
+                        .requiredWidth(maxWidth + Padding.sixteen)
+                        .offset(x = (-8).dp)
+                        .fillMaxWidth(),
+                    value = state.email ?: stringResource(id = StringsIds.empty),
+                    onValueChange = { newEmail -> viewModel.onEmailValueChanged(newEmail = newEmail) },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+                    textStyle = TextStyles.body,
+                    singleLine = true,
+                    colors = TextFieldDefaults.textFieldColors(backgroundColor = Colors.whiteColor)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(Padding.four))
+
+            BoxWithConstraints(
+                modifier = Modifier.clipToBounds()
+            ) {
+                TextField(
+                    label = { Text(text = stringResource(id = StringsIds.password)) },
+                    modifier = Modifier
+                        .requiredWidth(maxWidth + Padding.sixteen)
+                        .offset(x = (-8).dp)
+                        .fillMaxWidth(),
+                    value = state.password ?: stringResource(id = StringsIds.empty),
+                    onValueChange = { newPassword -> viewModel.onPasswordValueChanged(newPassword = newPassword) },
+                    visualTransformation = PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                    textStyle = TextStyles.body,
+                    singleLine = true,
+                    colors = TextFieldDefaults.textFieldColors(backgroundColor = Colors.whiteColor)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(Padding.eight))
+
+            Button(
+                onClick = {  },
+                shape = RoundedCornerShape(size = 50.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(Padding.twentyFour),
+                colors = ButtonDefaults.buttonColors(backgroundColor = Colors.secondaryColor),
+                content = {
+                    Text(
+                        text = stringResource(id = StringsIds.createAccount),
+                        style = TextStyles.small,
+                        color = Color.White
+                    )
+                }
             )
         }
     }

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountScreen.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountScreen.kt
@@ -1,7 +1,8 @@
 package com.nicholas.rutherford.track.my.shot.feature.create.account
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
@@ -13,6 +14,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.nicholas.rutherford.track.my.shot.feature.splash.StringsIds
+import com.nicholas.rutherford.track.my.shot.helper.ui.Padding
 
 @Composable
 fun CreateAccountScreen(viewModel: CreateAccountViewModel) {
@@ -30,5 +32,13 @@ fun CreateAccountScreen(viewModel: CreateAccountViewModel) {
                 }
             }
         )
+
+        Spacer(modifier = Modifier.height(Padding.eight))
+
+        Column(modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(Padding.twenty)) {
+            Text(
+                text = "Enter All Fields To Create Account"
+            )
+        }
     }
 }

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountScreen.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountScreen.kt
@@ -1,0 +1,34 @@
+package com.nicholas.rutherford.track.my.shot.feature.create.account
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.nicholas.rutherford.track.my.shot.feature.splash.StringsIds
+
+@Composable
+fun CreateAccountScreen(viewModel: CreateAccountViewModel) {
+    val state = viewModel.createAccountStateFlow.collectAsState().value
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            title = {
+                Text(text = stringResource(id = StringsIds.createAccount))
+            }, navigationIcon = {
+                IconButton(onClick = { viewModel.onBackButtonClicked() }) {
+                    Icon(
+                        imageVector = Icons.Filled.ArrowBack, contentDescription = stringResource(id = StringsIds.empty)
+                    )
+                }
+            }
+        )
+    }
+}

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountScreen.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountScreen.kt
@@ -1,11 +1,9 @@
 package com.nicholas.rutherford.track.my.shot.feature.create.account
 
-import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
@@ -21,6 +19,23 @@ import com.nicholas.rutherford.track.my.shot.feature.splash.Colors
 import com.nicholas.rutherford.track.my.shot.feature.splash.StringsIds
 import com.nicholas.rutherford.track.my.shot.helper.ui.Padding
 import com.nicholas.rutherford.track.my.shot.helper.ui.TextStyles
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.material.Button
+import androidx.compose.material.TextField
+import androidx.compose.material.IconButton
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.ButtonDefaults
 
 @Composable
 fun CreateAccountScreen(viewModel: CreateAccountViewModel) {

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountScreen.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountScreen.kt
@@ -1,9 +1,26 @@
 package com.nicholas.rutherford.track.my.shot.feature.create.account
 
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
@@ -19,23 +36,6 @@ import com.nicholas.rutherford.track.my.shot.feature.splash.Colors
 import com.nicholas.rutherford.track.my.shot.feature.splash.StringsIds
 import com.nicholas.rutherford.track.my.shot.helper.ui.Padding
 import com.nicholas.rutherford.track.my.shot.helper.ui.TextStyles
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredWidth
-import androidx.compose.foundation.layout.offset
-import androidx.compose.material.Button
-import androidx.compose.material.TextField
-import androidx.compose.material.IconButton
-import androidx.compose.material.Icon
-import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
-import androidx.compose.material.TextFieldDefaults
-import androidx.compose.material.ButtonDefaults
 
 @Composable
 fun CreateAccountScreen(viewModel: CreateAccountViewModel) {
@@ -46,12 +46,15 @@ fun CreateAccountScreen(viewModel: CreateAccountViewModel) {
             title = {
                 Text(text = stringResource(id = StringsIds.createAccount))
             }, navigationIcon = {
-                IconButton(onClick = { viewModel.onBackButtonClicked() }) {
-                    Icon(
-                        imageVector = Icons.Filled.ArrowBack, contentDescription = stringResource(id = StringsIds.empty)
+            IconButton(onClick = { viewModel.onBackButtonClicked() }) {
+                Icon(
+                    imageVector = Icons.Filled.ArrowBack,
+                    contentDescription = stringResource(
+                        id = StringsIds.empty
                     )
-                }
+                )
             }
+        }
         )
 
         Spacer(modifier = Modifier.height(Padding.eight))
@@ -81,7 +84,10 @@ fun CreateAccountScreen(viewModel: CreateAccountViewModel) {
                         .fillMaxWidth(),
                     value = state.username ?: stringResource(id = StringsIds.empty),
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
-                    onValueChange = { newUsername -> viewModel.onUsernameValueChanged(newUsername = newUsername) },
+                    onValueChange = {
+                        newUsername ->
+                        viewModel.onUsernameValueChanged(newUsername = newUsername)
+                    },
                     textStyle = TextStyles.body,
                     singleLine = true,
                     colors = TextFieldDefaults.textFieldColors(backgroundColor = Colors.whiteColor)
@@ -100,7 +106,10 @@ fun CreateAccountScreen(viewModel: CreateAccountViewModel) {
                         .offset(x = (-8).dp)
                         .fillMaxWidth(),
                     value = state.email ?: stringResource(id = StringsIds.empty),
-                    onValueChange = { newEmail -> viewModel.onEmailValueChanged(newEmail = newEmail) },
+                    onValueChange = {
+                        newEmail ->
+                        viewModel.onEmailValueChanged(newEmail = newEmail)
+                    },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
                     textStyle = TextStyles.body,
                     singleLine = true,
@@ -120,7 +129,10 @@ fun CreateAccountScreen(viewModel: CreateAccountViewModel) {
                         .offset(x = (-8).dp)
                         .fillMaxWidth(),
                     value = state.password ?: stringResource(id = StringsIds.empty),
-                    onValueChange = { newPassword -> viewModel.onPasswordValueChanged(newPassword = newPassword) },
+                    onValueChange = {
+                        newPassword ->
+                        viewModel.onPasswordValueChanged(newPassword = newPassword)
+                    },
                     visualTransformation = PasswordVisualTransformation(),
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
                     textStyle = TextStyles.body,
@@ -132,7 +144,7 @@ fun CreateAccountScreen(viewModel: CreateAccountViewModel) {
             Spacer(modifier = Modifier.height(Padding.eight))
 
             Button(
-                onClick = {  },
+                onClick = { },
                 shape = RoundedCornerShape(size = 50.dp),
                 modifier = Modifier
                     .fillMaxWidth()

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountState.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountState.kt
@@ -1,0 +1,5 @@
+package com.nicholas.rutherford.track.my.shot.feature.create.account
+
+data class CreateAccountState(
+    val email: String?
+)

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountState.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountState.kt
@@ -1,5 +1,7 @@
 package com.nicholas.rutherford.track.my.shot.feature.create.account
 
 data class CreateAccountState(
-    val email: String?
+    val username: String?,
+    val email: String?,
+    val password: String?
 )

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountViewModel.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountViewModel.kt
@@ -6,7 +6,13 @@ import kotlinx.coroutines.flow.asStateFlow
 
 class CreateAccountViewModel(private val navigation: CreateAccountNavigation) : ViewModel() {
 
-    private val createAccountMutableStateFlow = MutableStateFlow(value = CreateAccountState(username = null, email = null, password = null))
+    private val createAccountMutableStateFlow = MutableStateFlow(
+        value = CreateAccountState(
+            username = null,
+            email = null,
+            password = null
+        )
+    )
     val createAccountStateFlow = createAccountMutableStateFlow.asStateFlow()
 
     fun onBackButtonClicked() = navigation.pop()

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountViewModel.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountViewModel.kt
@@ -1,0 +1,13 @@
+package com.nicholas.rutherford.track.my.shot.feature.create.account
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class CreateAccountViewModel(private val navigation: CreateAccountNavigation) : ViewModel() {
+
+    private val createAccountMutableStateFlow = MutableStateFlow(value = CreateAccountState(email = null))
+    val createAccountStateFlow = createAccountMutableStateFlow.asStateFlow()
+
+    fun onBackButtonClicked() = navigation.pop()
+}

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountViewModel.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountViewModel.kt
@@ -6,8 +6,20 @@ import kotlinx.coroutines.flow.asStateFlow
 
 class CreateAccountViewModel(private val navigation: CreateAccountNavigation) : ViewModel() {
 
-    private val createAccountMutableStateFlow = MutableStateFlow(value = CreateAccountState(email = null))
+    private val createAccountMutableStateFlow = MutableStateFlow(value = CreateAccountState(username = null, email = null, password = null))
     val createAccountStateFlow = createAccountMutableStateFlow.asStateFlow()
 
     fun onBackButtonClicked() = navigation.pop()
+
+    fun onUsernameValueChanged(newUsername: String) {
+        createAccountMutableStateFlow.value = createAccountStateFlow.value.copy(username = newUsername)
+    }
+
+    fun onEmailValueChanged(newEmail: String) {
+        createAccountMutableStateFlow.value = createAccountStateFlow.value.copy(email = newEmail)
+    }
+
+    fun onPasswordValueChanged(newPassword: String) {
+        createAccountMutableStateFlow.value = createAccountStateFlow.value.copy(password = newPassword)
+    }
 }

--- a/feature/create-account/src/test/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountViewModelTest.kt
+++ b/feature/create-account/src/test/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountViewModelTest.kt
@@ -12,7 +12,7 @@ class CreateAccountViewModelTest {
 
     private var navigation = mockk<CreateAccountNavigation>(relaxed = true)
 
-    private val state = CreateAccountState(email = null)
+    private val state = CreateAccountState(username = null, email = null, password = null)
 
     @BeforeEach
     fun beforeEach() {
@@ -29,5 +29,38 @@ class CreateAccountViewModelTest {
         viewModel.onBackButtonClicked()
 
         verify { navigation.pop() }
+    }
+
+    @Test fun `on user name value changed should update username state value`() {
+        val usernameTest = "user name 1"
+
+        viewModel.onUsernameValueChanged(newUsername = usernameTest)
+
+        Assertions.assertEquals(
+            viewModel.createAccountStateFlow.value,
+            state.copy(username = usernameTest)
+        )
+    }
+
+    @Test fun `on email value changed should update email state value`() {
+        val emailTest = "new email"
+
+        viewModel.onEmailValueChanged(newEmail = emailTest)
+
+        Assertions.assertEquals(
+            viewModel.createAccountStateFlow.value,
+            state.copy(email = emailTest)
+        )
+    }
+
+    @Test fun `on password value changed should update password state value`() {
+        val passwordTest = "new password"
+
+        viewModel.onPasswordValueChanged(newPassword = passwordTest)
+
+        Assertions.assertEquals(
+            viewModel.createAccountStateFlow.value,
+            state.copy(password = passwordTest)
+        )
     }
 }

--- a/feature/create-account/src/test/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountViewModelTest.kt
+++ b/feature/create-account/src/test/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountViewModelTest.kt
@@ -1,0 +1,33 @@
+package com.nicholas.rutherford.track.my.shot.feature.create.account
+
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CreateAccountViewModelTest {
+
+    private lateinit var viewModel: CreateAccountViewModel
+
+    private var navigation = mockk<CreateAccountNavigation>(relaxed = true)
+
+    private val state = CreateAccountState(email = null)
+
+    @BeforeEach
+    fun beforeEach() {
+        viewModel = CreateAccountViewModel(navigation = navigation)
+    }
+
+    @Test
+    fun initializeCreateAccountState() {
+        Assertions.assertEquals(
+            viewModel.createAccountStateFlow.value, state
+        ) }
+
+    @Test fun `on back button clicked should pop`() {
+        viewModel.onBackButtonClicked()
+
+        verify { navigation.pop() }
+    }
+}

--- a/feature/create-account/src/test/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountViewModelTest.kt
+++ b/feature/create-account/src/test/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountViewModelTest.kt
@@ -23,7 +23,8 @@ class CreateAccountViewModelTest {
     fun initializeCreateAccountState() {
         Assertions.assertEquals(
             viewModel.createAccountStateFlow.value, state
-        ) }
+        )
+    }
 
     @Test fun `on back button clicked should pop`() {
         viewModel.onBackButtonClicked()

--- a/feature/forgot-password/src/test/java/com/nicholas/rutherford/track/my/shot/feature/forgot/password/ForgotPasswordViewModelTest.kt
+++ b/feature/forgot-password/src/test/java/com/nicholas/rutherford/track/my/shot/feature/forgot/password/ForgotPasswordViewModelTest.kt
@@ -28,7 +28,7 @@ class ForgotPasswordViewModelTest {
     }
 
     @Test
-    fun `on back button clicked should pop to forgot password`() {
+    fun `on back button clicked should pop`() {
         viewModel.onBackButtonClicked()
 
         verify { navigation.pop() }

--- a/feature/login/src/main/java/com/nicholas/rutherford/track/my/shot/feature/login/LoginNavigationImpl.kt
+++ b/feature/login/src/main/java/com/nicholas/rutherford/track/my/shot/feature/login/LoginNavigationImpl.kt
@@ -7,9 +7,7 @@ class LoginNavigationImpl(private val navigator: Navigator) : LoginNavigation {
 
     override fun navigateToHome() = navigator.navigate(navigationAction = NavigationActions.LoginScreen.home())
 
-    // todo
-    override fun navigateToCreateAccount() = Unit
+    override fun navigateToCreateAccount() = navigator.navigate(navigationAction = NavigationActions.LoginScreen.createAccount())
 
-    // todo
     override fun navigateToForgotPassword() = navigator.navigate(navigationAction = NavigationActions.LoginScreen.forgotPassword())
 }

--- a/feature/login/src/main/java/com/nicholas/rutherford/track/my/shot/feature/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/nicholas/rutherford/track/my/shot/feature/login/LoginScreen.kt
@@ -120,7 +120,7 @@ fun LoginScreen(viewModel: LoginViewModel) {
         Spacer(modifier = Modifier.height(Padding.eight))
         ClickableText(
             text = AnnotatedString(stringResource(id = StringsIds.clickMeToCreateAccount)),
-            onClick = { },
+            onClick = { viewModel.onCreateAccountClicked() },
             style = TextStyles.hyperLink
         )
     }

--- a/navigation/src/main/java/com/nicholas/rutherford/track/my/shot/navigation/NavigationActions.kt
+++ b/navigation/src/main/java/com/nicholas/rutherford/track/my/shot/navigation/NavigationActions.kt
@@ -28,6 +28,12 @@ object NavigationActions {
                 .setLaunchSingleTop(true)
                 .build()
         }
+
+        fun createAccount() = object : NavigationAction {
+            override val destination = NavigationDestinations.CREATE_ACCOUNT_SCREEN
+            override val navOptions = NavOptions.Builder()
+                .build()
+        }
         fun forgotPassword() = object : NavigationAction {
             override val destination = NavigationDestinations.FORGOT_PASSWORD_SCREEN
             override val navOptions = NavOptions.Builder()

--- a/navigation/src/main/java/com/nicholas/rutherford/track/my/shot/navigation/NavigationComponent.kt
+++ b/navigation/src/main/java/com/nicholas/rutherford/track/my/shot/navigation/NavigationComponent.kt
@@ -19,7 +19,8 @@ fun NavigationComponent(
     splashContent: @Composable (navController: Navigator) -> Unit,
     loginContent: @Composable (navController: Navigator) -> Unit,
     homeContent: @Composable (navController: Navigator) -> Unit,
-    forgotPasswordContent: @Composable (navController: Navigator) -> Unit
+    forgotPasswordContent: @Composable (navController: Navigator) -> Unit,
+    createAccountContent: @Composable (navController: Navigator) -> Unit
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
     val navigatorState by navigator.navActions.asLifecycleAwareState(
@@ -61,6 +62,9 @@ fun NavigationComponent(
         }
         composable(route = NavigationDestinations.FORGOT_PASSWORD_SCREEN) {
             forgotPasswordContent.invoke(navigator)
+        }
+        composable(route = NavigationDestinations.CREATE_ACCOUNT_SCREEN) {
+            createAccountContent.invoke(navigator)
         }
     }
 }

--- a/navigation/src/main/java/com/nicholas/rutherford/track/my/shot/navigation/NavigationDestinations.kt
+++ b/navigation/src/main/java/com/nicholas/rutherford/track/my/shot/navigation/NavigationDestinations.kt
@@ -1,6 +1,7 @@
 package com.nicholas.rutherford.track.my.shot.navigation
 
 object NavigationDestinations {
+    const val CREATE_ACCOUNT_SCREEN = "createAccountScreen"
     const val FORGOT_PASSWORD_SCREEN = "forgotPasswordScreen"
     const val HOME_SCREEN = "homeScreen"
     const val LOGIN_SCREEN = "loginScreen"

--- a/navigation/src/test/java/com/nicholas/rutherford/track/my/shot/navigation/NavigationActionsTest.kt
+++ b/navigation/src/test/java/com/nicholas/rutherford/track/my/shot/navigation/NavigationActionsTest.kt
@@ -58,6 +58,18 @@ class NavigationActionsTest {
                     )
                 }
 
+                @Test fun createAccount() {
+                    Assertions.assertEquals(
+                        Actions.LoginScreen.createAccount().destination,
+                        NavigationDestinations.CREATE_ACCOUNT_SCREEN
+                    )
+                    Assertions.assertEquals(
+                        Actions.LoginScreen.createAccount().navOptions,
+                        NavOptions.Builder()
+                            .build()
+                    )
+                }
+
                 @Test fun forgot() {
                     Assertions.assertEquals(
                         Actions.LoginScreen.forgotPassword().destination,

--- a/navigation/src/test/java/com/nicholas/rutherford/track/my/shot/navigation/NavigationDestinationsTest.kt
+++ b/navigation/src/test/java/com/nicholas/rutherford/track/my/shot/navigation/NavigationDestinationsTest.kt
@@ -9,6 +9,7 @@ class NavigationDestinationsTest {
 
     lateinit var navigationDestinations: NavigationDestinations
 
+    internal val createAccountScreen = "createAccountScreen"
     internal val forgotPasswordScreen = "forgotPasswordScreen"
     internal val homeScreen = "homeScreen"
     internal val loginScreen = "loginScreen"
@@ -38,6 +39,11 @@ class NavigationDestinationsTest {
         @Test
         fun `splash screen name should result in splash screen`() {
             Assertions.assertEquals(navigationDestinations.SPLASH_SCREEN, splashScreen)
+        }
+
+        @Test
+        fun `create account screen name should result in create account screen`() {
+            Assertions.assertEquals(navigationDestinations.CREATE_ACCOUNT_SCREEN, createAccountScreen)
         }
     }
 }


### PR DESCRIPTION
### Trello
https://trello.com/c/4uec61X9/55-create-ui-around-create-account-view

### Issues
- To integrate with firebase in the future, we need a pretty basic create account screen that takes in a username, email, and password. We currently don't have that screen, hence we need to create a new view. 

### Proposed Changes
- Create said new UI 

### TO-DO
- Introduce `:compose-components` module to introduce actual components in the app. 
- Intergate with realtime database -> firebase. 
- Prob some clean up with our UI screens we have been introducing. 

### Additional Info
- N/A 

### Screenshots / Videos 
![Screenshot_20221214-180242](https://user-images.githubusercontent.com/30304972/207741593-d1f342d8-7db9-40c1-9ef8-52a8a28c5399.jpg)

