### PR TITLE
nick: Turn toolbar and content view to a stock compose component

### DIFF
--- a/compose-components/build.gradle.kts
+++ b/compose-components/build.gradle.kts
@@ -66,5 +66,7 @@ android {
 }
 
 dependencies {
+    api(project(path = ":helper:ui"))
+
     implementation(Dependencies.Compose.material)
 }

--- a/compose-components/src/main/java/com/nicholas/rutherford/track/my/shot/compose/components/ContentWithTopBackAppBar.kt
+++ b/compose-components/src/main/java/com/nicholas/rutherford/track/my/shot/compose/components/ContentWithTopBackAppBar.kt
@@ -28,13 +28,13 @@ fun ContentWithTopBackAppBar(
             title = {
                 Text(text = toolbarTitle)
             }, navigationIcon = {
-                IconButton(onClick = { onBackButtonClicked.invoke() }) {
-                    Icon(
-                        imageVector = Icons.Filled.ArrowBack,
-                        contentDescription = stringResource(id = iconContentDescription)
-                    )
-                }
+            IconButton(onClick = { onBackButtonClicked.invoke() }) {
+                Icon(
+                    imageVector = Icons.Filled.ArrowBack,
+                    contentDescription = stringResource(id = iconContentDescription)
+                )
             }
+        }
         )
 
         Spacer(modifier = Modifier.height(Padding.eight))

--- a/compose-components/src/main/java/com/nicholas/rutherford/track/my/shot/compose/components/ContentWithTopBackAppBar.kt
+++ b/compose-components/src/main/java/com/nicholas/rutherford/track/my/shot/compose/components/ContentWithTopBackAppBar.kt
@@ -12,14 +12,16 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.nicholas.rutherford.track.my.shot.feature.splash.StringsIds
 import com.nicholas.rutherford.track.my.shot.helper.ui.Padding
 
 @Composable
 fun ContentWithTopBackAppBar(
     toolbarTitle: String,
     onBackButtonClicked: (() -> Unit),
-    iconContentDescription: String,
-    content: @Composable () -> Unit
+    content: @Composable () -> Unit,
+    iconContentDescription: Int = StringsIds.empty,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(
@@ -29,7 +31,7 @@ fun ContentWithTopBackAppBar(
                 IconButton(onClick = { onBackButtonClicked.invoke() }) {
                     Icon(
                         imageVector = Icons.Filled.ArrowBack,
-                        contentDescription = iconContentDescription
+                        contentDescription = stringResource(id = iconContentDescription)
                     )
                 }
             }

--- a/compose-components/src/main/java/com/nicholas/rutherford/track/my/shot/compose/components/ContentWithTopBackAppBar.kt
+++ b/compose-components/src/main/java/com/nicholas/rutherford/track/my/shot/compose/components/ContentWithTopBackAppBar.kt
@@ -1,13 +1,11 @@
 package com.nicholas.rutherford.track.my.shot.compose.components
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
+import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
@@ -16,6 +14,14 @@ import androidx.compose.ui.res.stringResource
 import com.nicholas.rutherford.track.my.shot.feature.splash.StringsIds
 import com.nicholas.rutherford.track.my.shot.helper.ui.Padding
 
+/**
+ * Default Content with Top back arrow bar, used for content views
+ *
+ * @param toolbarTitle sets the title of the [TopAppBar]
+ * @param onBackButtonClicked executes whenever the user clicks the [TopAppBar] back button
+ * @param content [Composable] used to set body of content below the [TopAppBar]
+ * @param iconContentDescription optional param responsible for setting description for back arrow button
+ */
 @Composable
 fun ContentWithTopBackAppBar(
     toolbarTitle: String,

--- a/compose-components/src/main/java/com/nicholas/rutherford/track/my/shot/compose/components/ContentWithTopBackAppBar.kt
+++ b/compose-components/src/main/java/com/nicholas/rutherford/track/my/shot/compose/components/ContentWithTopBackAppBar.kt
@@ -1,11 +1,13 @@
 package com.nicholas.rutherford.track.my.shot.compose.components
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.material.*
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
@@ -15,7 +17,7 @@ import com.nicholas.rutherford.track.my.shot.feature.splash.StringsIds
 import com.nicholas.rutherford.track.my.shot.helper.ui.Padding
 
 /**
- * Default Content with Top back arrow bar, used for content views
+ * Default Content with back [TopAppBar]. Used for default content views
  *
  * @param toolbarTitle sets the title of the [TopAppBar]
  * @param onBackButtonClicked executes whenever the user clicks the [TopAppBar] back button

--- a/compose-components/src/main/java/com/nicholas/rutherford/track/my/shot/compose/components/ContentWithTopBackAppBar.kt
+++ b/compose-components/src/main/java/com/nicholas/rutherford/track/my/shot/compose/components/ContentWithTopBackAppBar.kt
@@ -1,0 +1,42 @@
+package com.nicholas.rutherford.track.my.shot.compose.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.nicholas.rutherford.track.my.shot.helper.ui.Padding
+
+@Composable
+fun ContentWithTopBackAppBar(
+    toolbarTitle: String,
+    onBackButtonClicked: (() -> Unit),
+    iconContentDescription: String,
+    content: @Composable () -> Unit
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            title = {
+                Text(text = toolbarTitle)
+            }, navigationIcon = {
+                IconButton(onClick = { onBackButtonClicked.invoke() }) {
+                    Icon(
+                        imageVector = Icons.Filled.ArrowBack,
+                        contentDescription = iconContentDescription
+                    )
+                }
+            }
+        )
+
+        Spacer(modifier = Modifier.height(Padding.eight))
+
+        content.invoke()
+    }
+}

--- a/feature/create-account/build.gradle.kts
+++ b/feature/create-account/build.gradle.kts
@@ -67,6 +67,7 @@ android {
 
 dependencies {
     api(project(path = ":base-resources"))
+    api(project(path = ":compose-components"))
     api(project(path = ":helper:ui"))
     api(project(path = ":navigation"))
 

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountScreen.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountScreen.kt
@@ -1,11 +1,23 @@
 package com.nicholas.rutherford.track.my.shot.feature.create.account
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.*
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
@@ -65,7 +77,7 @@ fun CreateAccountScreenContent(
                 value = state.username ?: stringResource(id = StringsIds.empty),
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
                 onValueChange = {
-                        newUsername ->
+                    newUsername ->
                     viewModel.onUsernameValueChanged(newUsername = newUsername)
                 },
                 textStyle = TextStyles.body,
@@ -87,7 +99,7 @@ fun CreateAccountScreenContent(
                     .fillMaxWidth(),
                 value = state.email ?: stringResource(id = StringsIds.empty),
                 onValueChange = {
-                        newEmail ->
+                    newEmail ->
                     viewModel.onEmailValueChanged(newEmail = newEmail)
                 },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
@@ -110,7 +122,7 @@ fun CreateAccountScreenContent(
                     .fillMaxWidth(),
                 value = state.password ?: stringResource(id = StringsIds.empty),
                 onValueChange = {
-                        newPassword ->
+                    newPassword ->
                     viewModel.onPasswordValueChanged(newPassword = newPassword)
                 },
                 visualTransformation = PasswordVisualTransformation(),

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountScreen.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountScreen.kt
@@ -1,28 +1,11 @@
 package com.nicholas.rutherford.track.my.shot.feature.create.account
 
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.Text
-import androidx.compose.material.TextField
-import androidx.compose.material.TextFieldDefaults
-import androidx.compose.material.TopAppBar
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
@@ -32,6 +15,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
+import com.nicholas.rutherford.track.my.shot.compose.components.ContentWithTopBackAppBar
 import com.nicholas.rutherford.track.my.shot.feature.splash.Colors
 import com.nicholas.rutherford.track.my.shot.feature.splash.StringsIds
 import com.nicholas.rutherford.track.my.shot.helper.ui.Padding
@@ -41,123 +25,118 @@ import com.nicholas.rutherford.track.my.shot.helper.ui.TextStyles
 fun CreateAccountScreen(viewModel: CreateAccountViewModel) {
     val state = viewModel.createAccountStateFlow.collectAsState().value
 
-    Column(modifier = Modifier.fillMaxSize()) {
-        TopAppBar(
-            title = {
-                Text(text = stringResource(id = StringsIds.createAccount))
-            }, navigationIcon = {
-            IconButton(onClick = { viewModel.onBackButtonClicked() }) {
-                Icon(
-                    imageVector = Icons.Filled.ArrowBack,
-                    contentDescription = stringResource(
-                        id = StringsIds.empty
-                    )
-                )
-            }
+    ContentWithTopBackAppBar(
+        toolbarTitle = stringResource(id = StringsIds.createAccount),
+        onBackButtonClicked = { viewModel.onBackButtonClicked() },
+        content = {
+            CreateAccountScreenContent(state = state, viewModel = viewModel)
         }
+    )
+}
+
+@Composable
+fun CreateAccountScreenContent(
+    state: CreateAccountState,
+    viewModel: CreateAccountViewModel
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(Padding.twenty)
+    ) {
+
+        Text(
+            text = stringResource(id = StringsIds.allFieldsAreRequired),
+            style = TextStyles.small
         )
+
+        Spacer(modifier = Modifier.height(Padding.four))
+
+        BoxWithConstraints(
+            modifier = Modifier.clipToBounds()
+        ) {
+            TextField(
+                label = { Text(text = stringResource(id = StringsIds.userName)) },
+                modifier = Modifier
+                    .requiredWidth(maxWidth + Padding.sixteen)
+                    .offset(x = (-8).dp)
+                    .fillMaxWidth(),
+                value = state.username ?: stringResource(id = StringsIds.empty),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+                onValueChange = {
+                        newUsername ->
+                    viewModel.onUsernameValueChanged(newUsername = newUsername)
+                },
+                textStyle = TextStyles.body,
+                singleLine = true,
+                colors = TextFieldDefaults.textFieldColors(backgroundColor = Colors.whiteColor)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(Padding.four))
+
+        BoxWithConstraints(
+            modifier = Modifier.clipToBounds()
+        ) {
+            TextField(
+                label = { Text(text = stringResource(id = StringsIds.email)) },
+                modifier = Modifier
+                    .requiredWidth(maxWidth + Padding.sixteen)
+                    .offset(x = (-8).dp)
+                    .fillMaxWidth(),
+                value = state.email ?: stringResource(id = StringsIds.empty),
+                onValueChange = {
+                        newEmail ->
+                    viewModel.onEmailValueChanged(newEmail = newEmail)
+                },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+                textStyle = TextStyles.body,
+                singleLine = true,
+                colors = TextFieldDefaults.textFieldColors(backgroundColor = Colors.whiteColor)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(Padding.four))
+
+        BoxWithConstraints(
+            modifier = Modifier.clipToBounds()
+        ) {
+            TextField(
+                label = { Text(text = stringResource(id = StringsIds.password)) },
+                modifier = Modifier
+                    .requiredWidth(maxWidth + Padding.sixteen)
+                    .offset(x = (-8).dp)
+                    .fillMaxWidth(),
+                value = state.password ?: stringResource(id = StringsIds.empty),
+                onValueChange = {
+                        newPassword ->
+                    viewModel.onPasswordValueChanged(newPassword = newPassword)
+                },
+                visualTransformation = PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                textStyle = TextStyles.body,
+                singleLine = true,
+                colors = TextFieldDefaults.textFieldColors(backgroundColor = Colors.whiteColor)
+            )
+        }
 
         Spacer(modifier = Modifier.height(Padding.eight))
 
-        Column(
+        Button(
+            onClick = { },
+            shape = RoundedCornerShape(size = 50.dp),
             modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .padding(Padding.twenty)
-        ) {
-
-            Text(
-                text = stringResource(id = StringsIds.allFieldsAreRequired),
-                style = TextStyles.small
-            )
-
-            Spacer(modifier = Modifier.height(Padding.four))
-
-            BoxWithConstraints(
-                modifier = Modifier.clipToBounds()
-            ) {
-                TextField(
-                    label = { Text(text = stringResource(id = StringsIds.userName)) },
-                    modifier = Modifier
-                        .requiredWidth(maxWidth + Padding.sixteen)
-                        .offset(x = (-8).dp)
-                        .fillMaxWidth(),
-                    value = state.username ?: stringResource(id = StringsIds.empty),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
-                    onValueChange = {
-                        newUsername ->
-                        viewModel.onUsernameValueChanged(newUsername = newUsername)
-                    },
-                    textStyle = TextStyles.body,
-                    singleLine = true,
-                    colors = TextFieldDefaults.textFieldColors(backgroundColor = Colors.whiteColor)
+                .fillMaxWidth()
+                .padding(Padding.twentyFour),
+            colors = ButtonDefaults.buttonColors(backgroundColor = Colors.secondaryColor),
+            content = {
+                Text(
+                    text = stringResource(id = StringsIds.createAccount),
+                    style = TextStyles.small,
+                    color = Color.White
                 )
             }
-
-            Spacer(modifier = Modifier.height(Padding.four))
-
-            BoxWithConstraints(
-                modifier = Modifier.clipToBounds()
-            ) {
-                TextField(
-                    label = { Text(text = stringResource(id = StringsIds.email)) },
-                    modifier = Modifier
-                        .requiredWidth(maxWidth + Padding.sixteen)
-                        .offset(x = (-8).dp)
-                        .fillMaxWidth(),
-                    value = state.email ?: stringResource(id = StringsIds.empty),
-                    onValueChange = {
-                        newEmail ->
-                        viewModel.onEmailValueChanged(newEmail = newEmail)
-                    },
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
-                    textStyle = TextStyles.body,
-                    singleLine = true,
-                    colors = TextFieldDefaults.textFieldColors(backgroundColor = Colors.whiteColor)
-                )
-            }
-
-            Spacer(modifier = Modifier.height(Padding.four))
-
-            BoxWithConstraints(
-                modifier = Modifier.clipToBounds()
-            ) {
-                TextField(
-                    label = { Text(text = stringResource(id = StringsIds.password)) },
-                    modifier = Modifier
-                        .requiredWidth(maxWidth + Padding.sixteen)
-                        .offset(x = (-8).dp)
-                        .fillMaxWidth(),
-                    value = state.password ?: stringResource(id = StringsIds.empty),
-                    onValueChange = {
-                        newPassword ->
-                        viewModel.onPasswordValueChanged(newPassword = newPassword)
-                    },
-                    visualTransformation = PasswordVisualTransformation(),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                    textStyle = TextStyles.body,
-                    singleLine = true,
-                    colors = TextFieldDefaults.textFieldColors(backgroundColor = Colors.whiteColor)
-                )
-            }
-
-            Spacer(modifier = Modifier.height(Padding.eight))
-
-            Button(
-                onClick = { },
-                shape = RoundedCornerShape(size = 50.dp),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(Padding.twentyFour),
-                colors = ButtonDefaults.buttonColors(backgroundColor = Colors.secondaryColor),
-                content = {
-                    Text(
-                        text = stringResource(id = StringsIds.createAccount),
-                        style = TextStyles.small,
-                        color = Color.White
-                    )
-                }
-            )
-        }
+        )
     }
 }

--- a/feature/forgot-password/build.gradle.kts
+++ b/feature/forgot-password/build.gradle.kts
@@ -66,6 +66,7 @@ android {
 }
 
 dependencies {
+    api(project(path = ":compose-components"))
     api(project(path = ":base-resources"))
     api(project(path = ":helper:ui"))
     api(project(path = ":navigation"))

--- a/feature/forgot-password/build.gradle.kts
+++ b/feature/forgot-password/build.gradle.kts
@@ -66,8 +66,8 @@ android {
 }
 
 dependencies {
-    api(project(path = ":compose-components"))
     api(project(path = ":base-resources"))
+    api(project(path = ":compose-components"))
     api(project(path = ":helper:ui"))
     api(project(path = ":navigation"))
 

--- a/feature/forgot-password/src/main/java/com/nicholas/rutherford/track/my/shot/feature/forgot/password/ForgotPasswordScreen.kt
+++ b/feature/forgot-password/src/main/java/com/nicholas/rutherford/track/my/shot/feature/forgot/password/ForgotPasswordScreen.kt
@@ -34,8 +34,8 @@ fun ForgotPasswordScreen(viewModel: ForgotPasswordViewModel) {
         toolbarTitle = stringResource(id = StringsIds.forgotPassword),
         onBackButtonClicked = { viewModel.onBackButtonClicked() },
         content = {
-        ForgotPasswordScreenContent(state = state, viewModel = viewModel)
-    }
+            ForgotPasswordScreenContent(state = state, viewModel = viewModel)
+        }
     )
 }
 
@@ -44,10 +44,12 @@ fun ForgotPasswordScreenContent(
     state: ForgotPasswordState,
     viewModel: ForgotPasswordViewModel
 ) {
-    Column(modifier = Modifier
-        .fillMaxSize()
-        .verticalScroll(rememberScrollState())
-        .padding(14.dp)) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(14.dp)
+    ) {
         TextField(
             label = { Text(text = stringResource(id = StringsIds.forgotPassword)) },
             modifier = Modifier

--- a/feature/forgot-password/src/main/java/com/nicholas/rutherford/track/my/shot/feature/forgot/password/ForgotPasswordScreen.kt
+++ b/feature/forgot-password/src/main/java/com/nicholas/rutherford/track/my/shot/feature/forgot/password/ForgotPasswordScreen.kt
@@ -33,10 +33,9 @@ fun ForgotPasswordScreen(viewModel: ForgotPasswordViewModel) {
     ContentWithTopBackAppBar(
         toolbarTitle = stringResource(id = StringsIds.forgotPassword),
         onBackButtonClicked = { viewModel.onBackButtonClicked() },
-        iconContentDescription = stringResource(id = StringsIds.empty),
         content = {
-            ForgotPasswordScreenContent(state = state, viewModel = viewModel)
-        }
+        ForgotPasswordScreenContent(state = state, viewModel = viewModel)
+    }
     )
 }
 

--- a/feature/forgot-password/src/main/java/com/nicholas/rutherford/track/my/shot/feature/forgot/password/ForgotPasswordScreen.kt
+++ b/feature/forgot-password/src/main/java/com/nicholas/rutherford/track/my/shot/feature/forgot/password/ForgotPasswordScreen.kt
@@ -11,20 +11,16 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
-import androidx.compose.material.TopAppBar
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.nicholas.rutherford.track.my.shot.compose.components.ContentWithTopBackAppBar
 import com.nicholas.rutherford.track.my.shot.feature.splash.Colors
 import com.nicholas.rutherford.track.my.shot.feature.splash.StringsIds
 import com.nicholas.rutherford.track.my.shot.helper.ui.Padding
@@ -34,55 +30,53 @@ import com.nicholas.rutherford.track.my.shot.helper.ui.TextStyles
 fun ForgotPasswordScreen(viewModel: ForgotPasswordViewModel) {
     val state = viewModel.forgotPasswordStateFlow.collectAsState().value
 
-    Column(modifier = Modifier.fillMaxSize()) {
-        TopAppBar(
-            title = {
-                Text(text = stringResource(id = StringsIds.forgotPassword))
-            },
-            navigationIcon = {
-                IconButton(onClick = { viewModel.onBackButtonClicked() }) {
-                    Icon(
-                        imageVector = Icons.Filled.ArrowBack,
-                        contentDescription = stringResource(
-                            id = StringsIds.empty
-                        )
-                    )
-                }
-            }
+    ContentWithTopBackAppBar(
+        toolbarTitle = stringResource(id = StringsIds.forgotPassword),
+        onBackButtonClicked = { viewModel.onBackButtonClicked() },
+        iconContentDescription = stringResource(id = StringsIds.empty),
+        content = {
+            ForgotPasswordScreenContent(state = state, viewModel = viewModel)
+        }
+    )
+}
+
+@Composable
+fun ForgotPasswordScreenContent(
+    state: ForgotPasswordState,
+    viewModel: ForgotPasswordViewModel
+) {
+    Column(modifier = Modifier
+        .fillMaxSize()
+        .verticalScroll(rememberScrollState())
+        .padding(14.dp)) {
+        TextField(
+            label = { Text(text = stringResource(id = StringsIds.forgotPassword)) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(4.dp),
+            value = state.email ?: stringResource(id = StringsIds.empty),
+            onValueChange = { newEmail -> viewModel.onEmailValueChanged(newEmail = newEmail) },
+            textStyle = TextStyles.body,
+            singleLine = true,
+            colors = TextFieldDefaults.textFieldColors(backgroundColor = Colors.whiteColor)
         )
 
-        Spacer(modifier = Modifier.height(Padding.eight))
+        Spacer(modifier = Modifier.height(Padding.four))
 
-        Column(modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(14.dp)) {
-            TextField(
-                label = { Text(text = stringResource(id = StringsIds.forgotPassword)) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(4.dp),
-                value = state.email ?: stringResource(id = StringsIds.empty),
-                onValueChange = { newEmail -> viewModel.onEmailValueChanged(newEmail = newEmail) },
-                textStyle = TextStyles.body,
-                singleLine = true,
-                colors = TextFieldDefaults.textFieldColors(backgroundColor = Colors.whiteColor)
-            )
-
-            Spacer(modifier = Modifier.height(Padding.four))
-
-            Button(
-                onClick = { viewModel.onSendPasswordResetButtonClicked() },
-                shape = RoundedCornerShape(size = 50.dp),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(Padding.twentyFour),
-                colors = ButtonDefaults.buttonColors(backgroundColor = Colors.secondaryColor),
-                content = {
-                    Text(
-                        text = stringResource(id = StringsIds.resetPassword),
-                        style = TextStyles.small,
-                        color = Color.White
-                    )
-                }
-            )
-        }
+        Button(
+            onClick = { viewModel.onSendPasswordResetButtonClicked() },
+            shape = RoundedCornerShape(size = 50.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Padding.twentyFour),
+            colors = ButtonDefaults.buttonColors(backgroundColor = Colors.secondaryColor),
+            content = {
+                Text(
+                    text = stringResource(id = StringsIds.resetPassword),
+                    style = TextStyles.small,
+                    color = Color.White
+                )
+            }
+        )
     }
 }


### PR DESCRIPTION
### Trello
https://trello.com/c/up2u71m9/57-turn-toolbar-and-content-view-to-a-stock-compose-component

### Issues
- Since we now have a compose-component module, its the perfect time to introduce the `ContentWithTopBackAppBar` component. This component will get used for any screen, that as a back stack app bar that gets used. It is flexible to include the content when necessary 

### Proposed Changes
- Create said component 
- Update `CreateAccountScreen` and `ForgotPasswordScreen` to use said component.  

### TO-DO
- Turn the `TextField` with no padding that we are using for `CreateAccount` to include it as a component for retainability.

### Additional Info
- N/A 