### PR TITLE
nick: Introduce TextFieldNoPadding component 

### DIFF
--- a/compose-components/src/main/java/com/nicholas/rutherford/track/my/shot/compose/components/TextFieldNoPadding.kt
+++ b/compose-components/src/main/java/com/nicholas/rutherford/track/my/shot/compose/components/TextFieldNoPadding.kt
@@ -40,6 +40,7 @@ fun TextFieldNoPadding(
     singleLine: Boolean = true,
     colors: TextFieldColors = TextFieldDefaults.textFieldColors(backgroundColor = Colors.whiteColor)
 ) {
+    // removes the starting padding of the TextField
     val negativeOffSetPaddingX = (-8).dp
 
     BoxWithConstraints(

--- a/compose-components/src/main/java/com/nicholas/rutherford/track/my/shot/compose/components/TextFieldNoPadding.kt
+++ b/compose-components/src/main/java/com/nicholas/rutherford/track/my/shot/compose/components/TextFieldNoPadding.kt
@@ -1,0 +1,65 @@
+package com.nicholas.rutherford.track.my.shot.compose.components
+
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldColors
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.nicholas.rutherford.track.my.shot.feature.splash.Colors
+import com.nicholas.rutherford.track.my.shot.helper.ui.Padding
+import com.nicholas.rutherford.track.my.shot.helper.ui.TextStyles
+
+/**
+ * Default lightweight TextField with no default start padding
+ *
+ * @param label defined label that is the title text inside the [TextField]
+ * @param value defined value that is the body text inside the [TextField]
+ * @param onValueChange executes whenever the value is changed from the [TextField] gets the new value
+ * @param keyboardOptions sets the [KeyboardOptions] inside the [TextField]
+ * @param textStyle sets the [TextStyles] inside the [TextField]
+ * @param singleLine sets whenever the [TextField] is a single line or not
+ * @param colors sets the [TextFieldColors] inside the [TextField]
+ */
+@Composable
+fun TextFieldNoPadding(
+    label: String,
+    value: String,
+    onValueChange: ((String) -> Unit),
+    keyboardOptions: KeyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+    textStyle: TextStyle = TextStyles.body,
+    singleLine: Boolean = true,
+    colors: TextFieldColors = TextFieldDefaults.textFieldColors(backgroundColor = Colors.whiteColor)
+) {
+    val negativeOffSetPaddingX = (-8).dp
+
+    BoxWithConstraints(
+        modifier = Modifier.clipToBounds()
+    ) {
+        TextField(
+            label = { Text(text = label) },
+            modifier = Modifier
+                .requiredWidth(maxWidth + Padding.sixteen)
+                .offset(x = negativeOffSetPaddingX)
+                .fillMaxWidth(),
+            value = value,
+            keyboardOptions = keyboardOptions,
+            onValueChange = {
+                newUsername ->
+                onValueChange.invoke(newUsername)
+            },
+            textStyle = textStyle,
+            singleLine = singleLine,
+            colors = colors
+        )
+    }
+}

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountScreen.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountScreen.kt
@@ -1,14 +1,11 @@
 package com.nicholas.rutherford.track.my.shot.feature.create.account
 
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
@@ -16,18 +13,15 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Text
-import androidx.compose.material.TextField
-import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import com.nicholas.rutherford.track.my.shot.compose.components.ContentWithTopBackAppBar
+import com.nicholas.rutherford.track.my.shot.compose.components.TextFieldNoPadding
 import com.nicholas.rutherford.track.my.shot.feature.splash.Colors
 import com.nicholas.rutherford.track.my.shot.feature.splash.StringsIds
 import com.nicholas.rutherford.track.my.shot.helper.ui.Padding
@@ -65,73 +59,35 @@ fun CreateAccountScreenContent(
 
         Spacer(modifier = Modifier.height(Padding.four))
 
-        BoxWithConstraints(
-            modifier = Modifier.clipToBounds()
-        ) {
-            TextField(
-                label = { Text(text = stringResource(id = StringsIds.userName)) },
-                modifier = Modifier
-                    .requiredWidth(maxWidth + Padding.sixteen)
-                    .offset(x = (-8).dp)
-                    .fillMaxWidth(),
-                value = state.username ?: stringResource(id = StringsIds.empty),
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
-                onValueChange = {
-                    newUsername ->
-                    viewModel.onUsernameValueChanged(newUsername = newUsername)
-                },
-                textStyle = TextStyles.body,
-                singleLine = true,
-                colors = TextFieldDefaults.textFieldColors(backgroundColor = Colors.whiteColor)
-            )
-        }
+        TextFieldNoPadding(
+            label = stringResource(id = StringsIds.userName),
+            value = state.username ?: stringResource(id = StringsIds.empty),
+            onValueChange = { newUsername ->
+                viewModel.onUsernameValueChanged(newUsername = newUsername)
+            }
+        )
 
         Spacer(modifier = Modifier.height(Padding.four))
 
-        BoxWithConstraints(
-            modifier = Modifier.clipToBounds()
-        ) {
-            TextField(
-                label = { Text(text = stringResource(id = StringsIds.email)) },
-                modifier = Modifier
-                    .requiredWidth(maxWidth + Padding.sixteen)
-                    .offset(x = (-8).dp)
-                    .fillMaxWidth(),
-                value = state.email ?: stringResource(id = StringsIds.empty),
-                onValueChange = {
-                    newEmail ->
-                    viewModel.onEmailValueChanged(newEmail = newEmail)
-                },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
-                textStyle = TextStyles.body,
-                singleLine = true,
-                colors = TextFieldDefaults.textFieldColors(backgroundColor = Colors.whiteColor)
-            )
-        }
+        TextFieldNoPadding(
+            label = stringResource(id = StringsIds.email),
+            value = state.email ?: stringResource(id = StringsIds.empty),
+            onValueChange = { newEmail ->
+                viewModel.onEmailValueChanged(newEmail = newEmail)
+            },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email)
+        )
 
         Spacer(modifier = Modifier.height(Padding.four))
 
-        BoxWithConstraints(
-            modifier = Modifier.clipToBounds()
-        ) {
-            TextField(
-                label = { Text(text = stringResource(id = StringsIds.password)) },
-                modifier = Modifier
-                    .requiredWidth(maxWidth + Padding.sixteen)
-                    .offset(x = (-8).dp)
-                    .fillMaxWidth(),
-                value = state.password ?: stringResource(id = StringsIds.empty),
-                onValueChange = {
-                    newPassword ->
-                    viewModel.onPasswordValueChanged(newPassword = newPassword)
-                },
-                visualTransformation = PasswordVisualTransformation(),
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                textStyle = TextStyles.body,
-                singleLine = true,
-                colors = TextFieldDefaults.textFieldColors(backgroundColor = Colors.whiteColor)
-            )
-        }
+        TextFieldNoPadding(
+            label = stringResource(id = StringsIds.password),
+            value = state.password ?: stringResource(id = StringsIds.empty),
+            onValueChange = { newPassword ->
+                viewModel.onPasswordValueChanged(newPassword = newPassword)
+            },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)
+        )
 
         Spacer(modifier = Modifier.height(Padding.eight))
 


### PR DESCRIPTION
### Trello
https://trello.com/c/jqSdubb0/63-add-textfieldnopaddingcomponent

### Issues
- In the create account ui workflow, we created a TextField that calculates to no padding start of the given text inside of the TextField. We are replicating this functionality every single time we want to use this, when we don’t really need to do that. Instead we can abstract this functionality out into a component; so that way it can be reused across given screens.

### Proposed Changes
- Create a component called TextFieldNoPaddingComponent that is a simple component that adds no starting padding to the given textfield of the text inside of the `TextField`

### TO-DO
- N/A 

### Additional Info
- N/A 