### PR TITLE
nick: Add automatic ktlint format runs as part of our build process for all of our modules 

### DIFF
--- a/app-center/build.gradle.kts
+++ b/app-center/build.gradle.kts
@@ -55,6 +55,8 @@ android {
     tasks.withType<Test> {
         useJUnitPlatform()
     }
+
+    tasks.getByPath(TaskOptions.preBuildPath).dependsOn(TaskOptions.ktlintFormatPath)
 }
 
 dependencies {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,6 +84,8 @@ android {
     tasks.withType<Test> {
         useJUnitPlatform()
     }
+
+    tasks.getByPath(TaskOptions.preBuildPath).dependsOn(TaskOptions.ktlintFormatPath)
 }
 
 dependencies {

--- a/base-resources/build.gradle.kts
+++ b/base-resources/build.gradle.kts
@@ -55,6 +55,8 @@ android {
     tasks.withType<Test> {
         useJUnitPlatform()
     }
+
+    tasks.getByPath(TaskOptions.preBuildPath).dependsOn(TaskOptions.ktlintFormatPath)
 }
 
 dependencies {

--- a/build-type/build.gradle.kts
+++ b/build-type/build.gradle.kts
@@ -49,11 +49,13 @@ android {
         useJUnitPlatform()
     }
 
-    dependencies {
-        testImplementation(Dependencies.Junit.Jupiter.api)
-        testImplementation(Dependencies.Junit.Jupiter.params)
-        testImplementation(Dependencies.Junit.junit)
+    tasks.getByPath(TaskOptions.preBuildPath).dependsOn(TaskOptions.ktlintFormatPath)
+}
 
-        testRuntimeOnly(Dependencies.Junit.Jupiter.engine)
-    }
+dependencies {
+    testImplementation(Dependencies.Junit.Jupiter.api)
+    testImplementation(Dependencies.Junit.Jupiter.params)
+    testImplementation(Dependencies.Junit.junit)
+
+    testRuntimeOnly(Dependencies.Junit.Jupiter.engine)
 }

--- a/buildSrc/src/main/kotlin/TaskOptions.kt
+++ b/buildSrc/src/main/kotlin/TaskOptions.kt
@@ -1,0 +1,6 @@
+/**
+ * To define task options data */
+object TaskOptions {
+    const val preBuildPath = "preBuild"
+    const val ktlintFormatPath = "ktlintFormat"
+}

--- a/compose-components/build.gradle.kts
+++ b/compose-components/build.gradle.kts
@@ -63,6 +63,8 @@ android {
     tasks.withType<Test> {
         useJUnitPlatform()
     }
+
+    tasks.getByPath(TaskOptions.preBuildPath).dependsOn(TaskOptions.ktlintFormatPath)
 }
 
 dependencies {

--- a/feature/create-account/build.gradle.kts
+++ b/feature/create-account/build.gradle.kts
@@ -63,6 +63,8 @@ android {
     tasks.withType<Test> {
         useJUnitPlatform()
     }
+
+    tasks.getByPath(TaskOptions.preBuildPath).dependsOn(TaskOptions.ktlintFormatPath)
 }
 
 dependencies {

--- a/feature/forgot-password/build.gradle.kts
+++ b/feature/forgot-password/build.gradle.kts
@@ -63,6 +63,8 @@ android {
     tasks.withType<Test> {
         useJUnitPlatform()
     }
+
+    tasks.getByPath(TaskOptions.preBuildPath).dependsOn(TaskOptions.ktlintFormatPath)
 }
 
 dependencies {

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -63,6 +63,8 @@ android {
     tasks.withType<Test> {
         useJUnitPlatform()
     }
+
+    tasks.getByPath(TaskOptions.preBuildPath).dependsOn(TaskOptions.ktlintFormatPath)
 }
 
 dependencies {

--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -63,6 +63,8 @@ android {
     tasks.withType<Test> {
         useJUnitPlatform()
     }
+
+    tasks.getByPath(TaskOptions.preBuildPath).dependsOn(TaskOptions.ktlintFormatPath)
 }
 
 dependencies {

--- a/feature/splash/build.gradle.kts
+++ b/feature/splash/build.gradle.kts
@@ -63,6 +63,8 @@ android {
     tasks.withType<Test> {
         useJUnitPlatform()
     }
+
+    tasks.getByPath(TaskOptions.preBuildPath).dependsOn(TaskOptions.ktlintFormatPath)
 }
 
 dependencies {

--- a/helper/ui/build.gradle.kts
+++ b/helper/ui/build.gradle.kts
@@ -55,6 +55,8 @@ android {
     tasks.withType<Test> {
         useJUnitPlatform()
     }
+
+    tasks.getByPath(TaskOptions.preBuildPath).dependsOn(TaskOptions.ktlintFormatPath)
 }
 
 dependencies {

--- a/navigation/build.gradle.kts
+++ b/navigation/build.gradle.kts
@@ -63,6 +63,8 @@ android {
     tasks.withType<Test> {
         useJUnitPlatform()
     }
+
+    tasks.getByPath(TaskOptions.preBuildPath).dependsOn(TaskOptions.ktlintFormatPath)
 }
 
 dependencies {


### PR DESCRIPTION
### Trello
https://trello.com/c/vYXQz1dx/58-add-automatic-ktlint-format-runs-as-part-of-our-build-process

### Issues
- We need a way to execute `ktlintFormat` every single time that we run our project. This will make it so more things our caught as we are making changes, opposed to in the CI pipeline. 

### Proposed Changes
- Add task job on each module level. 

### TO-DO
- N/A 