### PR TITLE
nick: Update splash functionality to check if the user is logged in before navigating to login or home

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -123,4 +123,6 @@ dependencies {
     testImplementation(Dependencies.Junit.junit)
 
     testRuntimeOnly(Dependencies.Junit.Jupiter.engine)
+
+    testImplementation(Dependencies.Mockk.core)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -105,6 +105,7 @@ dependencies {
     implementation(Dependencies.Compose.navigation)
     implementation(Dependencies.Compose.material)
 
+    implementation(Dependencies.Firebase.authKtx)
     implementation(Dependencies.Firebase.bom)
 
     implementation(Dependencies.Koin.core)

--- a/app/src/main/java/com/nicholas/rutherford/track/my/shot/AppModule.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/my/shot/AppModule.kt
@@ -1,5 +1,6 @@
 package com.nicholas.rutherford.track.my.shot
 
+import com.google.firebase.auth.FirebaseAuth
 import com.nicholas.rutherford.track.my.shot.app.center.AppCenter
 import com.nicholas.rutherford.track.my.shot.app.center.AppCenterImpl
 import com.nicholas.rutherford.track.my.shot.build.type.BuildType
@@ -17,6 +18,8 @@ import com.nicholas.rutherford.track.my.shot.feature.login.LoginViewModel
 import com.nicholas.rutherford.track.my.shot.feature.splash.SplashNavigation
 import com.nicholas.rutherford.track.my.shot.feature.splash.SplashNavigationImpl
 import com.nicholas.rutherford.track.my.shot.feature.splash.SplashViewModel
+import com.nicholas.rutherford.track.my.shot.firebase.read.ReadFirebaseUserInfo
+import com.nicholas.rutherford.track.my.shot.firebase.read.ReadFirebaseUserInfoImpl
 import com.nicholas.rutherford.track.my.shot.navigation.Navigator
 import com.nicholas.rutherford.track.my.shot.navigation.NavigatorImpl
 import org.koin.android.ext.koin.androidApplication
@@ -26,6 +29,9 @@ import org.koin.dsl.module
 class AppModule {
 
     val modules = module {
+        single {
+            FirebaseAuth.getInstance()
+        }
         single<BuildType> {
             BuildTypeImpl(buildTypeValue = BuildConfig.BUILD_TYPE)
         }
@@ -47,11 +53,14 @@ class AppModule {
         single<CreateAccountNavigation> {
             CreateAccountNavigationImpl(navigator = get())
         }
+        single<ReadFirebaseUserInfo> {
+            ReadFirebaseUserInfoImpl(firebaseAuth = get())
+        }
         viewModel {
             MainActivityViewModel(appCenter = get())
         }
         viewModel {
-            SplashViewModel(navigation = get())
+            SplashViewModel(navigation = get(), readFirebaseUserInfo = get())
         }
         viewModel {
             LoginViewModel(navigation = get(), buildType = get())

--- a/app/src/test/java/com/nicholas/rutherford/track/my/shot/MyApplicationTest.kt
+++ b/app/src/test/java/com/nicholas/rutherford/track/my/shot/MyApplicationTest.kt
@@ -1,5 +1,6 @@
 package com.nicholas.rutherford.track.my.shot
 
+import com.google.firebase.auth.FirebaseAuth
 import com.nicholas.rutherford.track.my.shot.app.center.AppCenter
 import com.nicholas.rutherford.track.my.shot.build.type.BuildType
 import com.nicholas.rutherford.track.my.shot.feature.home.HomeViewModel
@@ -8,6 +9,9 @@ import com.nicholas.rutherford.track.my.shot.feature.login.LoginViewModel
 import com.nicholas.rutherford.track.my.shot.feature.splash.SplashNavigation
 import com.nicholas.rutherford.track.my.shot.feature.splash.SplashViewModel
 import com.nicholas.rutherford.track.my.shot.navigation.Navigator
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -23,6 +27,7 @@ import kotlin.test.assertNotNull
 
 class MyApplicationTest : KoinTest {
 
+    private val firebaseAuth: FirebaseAuth by inject()
     private val buildType: BuildType by inject()
     private val appCenter: AppCenter by inject()
     private val navigator: Navigator by inject()
@@ -55,8 +60,12 @@ class MyApplicationTest : KoinTest {
 
     @Test
     fun `start koin on create should inject modules with instances as not null`() {
+        mockkStatic(FirebaseAuth::class)
+        every { FirebaseAuth.getInstance() } returns mockk(relaxed = true)
+
         myApplication.startKoinOnCreate()
 
+        assertNotNull(firebaseAuth)
         assertNotNull(buildType)
         assertNotNull(appCenter)
         assertNotNull(navigator)

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -43,6 +43,7 @@ object Dependencies {
     }
 
     object Firebase {
+        const val authKtx = "com.google.firebase:firebase-auth-ktx:${Versions.Dependencies.Firebase.authKtx}"
         const val bom = "com.google.firebase:firebase-bom:${Versions.Dependencies.Firebase.bom}"
         const val databaseKts = "com.google.firebase.firebase-database-ktx"
     }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -40,6 +40,7 @@ object Versions {
         }
 
         object Firebase {
+            const val authKtx = "21.1.0"
             const val bom = "31.0.3"
         }
 

--- a/feature/splash/build.gradle.kts
+++ b/feature/splash/build.gradle.kts
@@ -70,6 +70,7 @@ android {
 dependencies {
     api(project(path = ":base-resources"))
     api(project(path = ":compose-components"))
+    api(project(path = ":firebase:read"))
     api(project(path = ":navigation"))
 
     implementation(Dependencies.Compose.material)

--- a/feature/splash/src/main/java/com/nicholas/rutherford/track/my/shot/feature/splash/SplashViewModel.kt
+++ b/feature/splash/src/main/java/com/nicholas/rutherford/track/my/shot/feature/splash/SplashViewModel.kt
@@ -2,6 +2,7 @@ package com.nicholas.rutherford.track.my.shot.feature.splash
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.nicholas.rutherford.track.my.shot.firebase.read.ReadFirebaseUserInfo
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -10,10 +11,7 @@ import kotlinx.coroutines.launch
 const val SPLASH_DELAY_IN_MILLIS = 4000L
 const val SPLASH_IMAGE_SCALE = 1f
 
-// todo - remove this, this is here until we have create account working as expected
-const val ALWAYS_LOGIN_TEST = true
-
-class SplashViewModel(private val navigation: SplashNavigation) : ViewModel() {
+class SplashViewModel(private val navigation: SplashNavigation, private val readFirebaseUserInfo: ReadFirebaseUserInfo) : ViewModel() {
 
     private val initializeSplashState = SplashState(
         backgroundColor = Colors.primaryColor,
@@ -31,18 +29,15 @@ class SplashViewModel(private val navigation: SplashNavigation) : ViewModel() {
     private fun delayAndNavigateToHomeOrLogin() {
         viewModelScope.launch {
             delay(timeMillis = SPLASH_DELAY_IN_MILLIS)
-            navigateLoginOrHome()
+            navigateToLoginOrHome()
         }
     }
 
-    private fun navigateLoginOrHome() {
-        // todo - determine if the user is signed in or not via firebase realtime databse
-        // todo - if they arent, navigate them to login
-        // todo - if they are, navigate them to home
-        if (ALWAYS_LOGIN_TEST) {
-            navigation.navigateToLogin()
-        } else {
+    private fun navigateToLoginOrHome() {
+        if (readFirebaseUserInfo.isLoggedIn) {
             navigation.navigateToHome()
+        } else {
+            navigation.navigateToLogin()
         }
     }
 }

--- a/feature/splash/src/test/java/com/nicholas/rutherford/track/my/shot/feature/splash/SplashViewModelTest.kt
+++ b/feature/splash/src/test/java/com/nicholas/rutherford/track/my/shot/feature/splash/SplashViewModelTest.kt
@@ -1,6 +1,8 @@
 package com.nicholas.rutherford.track.my.shot.feature.splash
 
+import com.nicholas.rutherford.track.my.shot.firebase.read.ReadFirebaseUserInfo
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -20,6 +22,9 @@ class SplashViewModelTest {
     lateinit var viewModel: SplashViewModel
 
     internal var navigation = mockk<SplashNavigation>(relaxed = true)
+    internal var readFirebaseUserInfo = mockk<ReadFirebaseUserInfo>(relaxed = true)
+
+    internal val delayTime = 4001L // needs 1 extra millisecond to account for function below call
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val dispatcher = StandardTestDispatcher()
@@ -28,7 +33,7 @@ class SplashViewModelTest {
     @BeforeEach
     fun beforeEach() {
         Dispatchers.setMain(dispatcher)
-        viewModel = SplashViewModel(navigation = navigation)
+        viewModel = SplashViewModel(navigation = navigation, readFirebaseUserInfo = readFirebaseUserInfo)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -67,10 +72,28 @@ class SplashViewModelTest {
 
         @OptIn(ExperimentalCoroutinesApi::class)
         @Test
-        fun `should delay for 4 seconds and verifies that it calls navigate to login`() = runTest {
-            delay(4001) // needs 1 extra millisecond to account for function below call
+        fun `should delay for 4 seconds and verifies that it calls navigateToLogin when isLoggedIn is set to false`() = runTest {
+            every { readFirebaseUserInfo.isLoggedIn } returns false
+
+            Dispatchers.setMain(dispatcher)
+            viewModel = SplashViewModel(navigation = navigation, readFirebaseUserInfo = readFirebaseUserInfo)
+
+            delay(delayTime)
 
             coVerify { navigation.navigateToLogin() }
+        }
+
+        @OptIn(ExperimentalCoroutinesApi::class)
+        @Test
+        fun `should delay for 4 seconds and verifies it calls navigateToHome when isLoggedIn is set to true`() = runTest {
+            every { readFirebaseUserInfo.isLoggedIn } returns true
+
+            Dispatchers.setMain(dispatcher)
+            viewModel = SplashViewModel(navigation = navigation, readFirebaseUserInfo = readFirebaseUserInfo)
+
+            delay(delayTime)
+
+            coVerify { navigation.navigateToHome() }
         }
     }
 }

--- a/firebase/read/build.gradle.kts
+++ b/firebase/read/build.gradle.kts
@@ -60,4 +60,6 @@ android {
 }
 
 dependencies {
+    implementation(Dependencies.Firebase.authKtx)
+    implementation(Dependencies.Firebase.bom)
 }

--- a/firebase/read/build.gradle.kts
+++ b/firebase/read/build.gradle.kts
@@ -62,4 +62,12 @@ android {
 dependencies {
     implementation(Dependencies.Firebase.authKtx)
     implementation(Dependencies.Firebase.bom)
+
+    testImplementation(Dependencies.Junit.Jupiter.api)
+    testImplementation(Dependencies.Junit.Jupiter.params)
+    testImplementation(Dependencies.Junit.junit)
+
+    testImplementation(Dependencies.Mockk.core)
+
+    testRuntimeOnly(Dependencies.Junit.Jupiter.engine)
 }

--- a/firebase/read/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/read/ReadFirebaseUserInfo.kt
+++ b/firebase/read/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/read/ReadFirebaseUserInfo.kt
@@ -1,0 +1,5 @@
+package com.nicholas.rutherford.track.my.shot.firebase.read
+
+interface ReadFirebaseUserInfo {
+    val isLoggedIn: Boolean
+}

--- a/firebase/read/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/read/ReadFirebaseUserInfoImpl.kt
+++ b/firebase/read/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/read/ReadFirebaseUserInfoImpl.kt
@@ -1,0 +1,8 @@
+package com.nicholas.rutherford.track.my.shot.firebase.read
+
+import com.google.firebase.auth.FirebaseAuth
+
+class ReadFirebaseUserInfoImpl(firebaseAuth: FirebaseAuth) : ReadFirebaseUserInfo {
+
+    override val isLoggedIn: Boolean = firebaseAuth.currentUser != null
+}

--- a/firebase/read/src/test/java/com/nicholas/rutherford/track/my/shot/firebase/read/ReadFirebaseUserInfoImplTest.kt
+++ b/firebase/read/src/test/java/com/nicholas/rutherford/track/my/shot/firebase/read/ReadFirebaseUserInfoImplTest.kt
@@ -1,0 +1,41 @@
+package com.nicholas.rutherford.track.my.shot.firebase.read
+
+import com.google.firebase.auth.FirebaseAuth
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class ReadFirebaseUserInfoImplTest {
+
+    lateinit var readFirebaseUserInfoImpl: ReadFirebaseUserInfoImpl
+
+    var firebaseAuth = mockk<FirebaseAuth>(relaxed = true)
+
+    @BeforeEach
+    fun beforeEach() {
+        readFirebaseUserInfoImpl = ReadFirebaseUserInfoImpl(firebaseAuth = firebaseAuth)
+    }
+
+    @Nested
+    inner class IsLoggedIn {
+
+        @Test
+        fun `when currentUser is set to null should set to false`() {
+            every { firebaseAuth.currentUser } returns null
+
+            readFirebaseUserInfoImpl = ReadFirebaseUserInfoImpl(firebaseAuth = firebaseAuth)
+
+            Assertions.assertEquals(false, readFirebaseUserInfoImpl.isLoggedIn)
+        }
+
+        @Test
+        fun `when currentUser is not set to null should be set to true`() {
+            readFirebaseUserInfoImpl = ReadFirebaseUserInfoImpl(firebaseAuth = firebaseAuth)
+
+            Assertions.assertEquals(true, readFirebaseUserInfoImpl.isLoggedIn)
+        }
+    }
+}


### PR DESCRIPTION
### Trello
https://trello.com/c/s4Qus3mc/66-update-splash-functionality-to-check-if-the-user-is-logged-in-before-navigating-to-login-or-home

### Issues
- The splash screen functionality, does not currently check to see if a given user is logged in via firebase. If a account is logged in via Firebase, we should not take user to the login screen and instead; take user to the Home Screen.

### Proposed Changes
- Add functionality to the splash screen, that checks to see if the user is logged in via firebase. If they are, take them to the Home Screen. If they re not; w e should then prompt them over to the login screen to login to a existing account; or create a account.

### TO-DO
- N/A 
