### PR TITLE
nick: Fix alert issue and rework the `NetworkImpl` functionality 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.nicholas.rutherford.track.my.shot">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".MyApplication"
         android:allowBackup="true"

--- a/app/src/main/java/com/nicholas/rutherford/track/my/shot/AppModule.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/my/shot/AppModule.kt
@@ -40,7 +40,7 @@ class AppModule {
             CreateFirebaseUserInfoImpl(firebaseAuth = get())
         }
         single<Network> {
-            NetworkImpl(application = androidApplication())
+            NetworkImpl()
         }
         single<BuildType> {
             BuildTypeImpl(buildTypeValue = BuildConfig.BUILD_TYPE)

--- a/feature/create-account/build.gradle.kts
+++ b/feature/create-account/build.gradle.kts
@@ -78,6 +78,8 @@ dependencies {
     implementation(Dependencies.Compose.material)
     implementation(Dependencies.Compose.viewModel)
 
+    testImplementation(Dependencies.Coroutine.test)
+
     testImplementation(Dependencies.Junit.Jupiter.api)
     testImplementation(Dependencies.Junit.Jupiter.params)
     testImplementation(Dependencies.Junit.junit)

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountViewModel.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountViewModel.kt
@@ -2,6 +2,7 @@ package com.nicholas.rutherford.track.my.shot.feature.create.account
 
 import android.app.Application
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.nicholas.rutherford.track.my.shot.data.shared.alert.Alert
 import com.nicholas.rutherford.track.my.shot.data.shared.alert.AlertConfirmAndDismissButton
 import com.nicholas.rutherford.track.my.shot.feature.splash.StringsIds
@@ -9,6 +10,7 @@ import com.nicholas.rutherford.track.my.shot.firebase.create.CreateFirebaseUserI
 import com.nicholas.rutherford.track.my.shot.helper.network.Network
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 class CreateAccountViewModel(
     private val navigation: CreateAccountNavigation,
@@ -41,7 +43,9 @@ class CreateAccountViewModel(
         setIsPasswordEmptyOrNull(password = createAccountState.password)
         setIsTwoOrMoreFieldsEmptyOrNull()
 
-        validateFields()
+        viewModelScope.launch {
+            validateFields()
+        }
     }
 
     internal fun setIsUsernameEmptyOrNull(username: String?) {
@@ -84,7 +88,7 @@ class CreateAccountViewModel(
         isTwoOrMoreFieldsEmptyOrNull = counter >= 2
     }
 
-    internal fun validateFields() {
+    internal suspend fun validateFields() {
         val defaultAlert = Alert(
             onDismissClicked = {},
             title = application.getString(StringsIds.empty),
@@ -101,9 +105,7 @@ class CreateAccountViewModel(
                     description = application.getString(StringsIds.deviceIsCurrentlyNotConnectedToInternetDesc)
                 )
             )
-        }
-
-        if (isTwoOrMoreFieldsEmptyOrNull) {
+        } else if (isTwoOrMoreFieldsEmptyOrNull) {
             navigation.alert(
                 alert = defaultAlert.copy(
                     title = application.getString(StringsIds.emptyFields),
@@ -134,17 +136,7 @@ class CreateAccountViewModel(
                 )
             )
         } else {
-            // test code not final
-//            viewModelScope.launch {
-//                navigation.enableProgress(
-//                    progress = Progress(
-//                        onDismissClicked = {}
-//                    )
-//                )
-//
-//                delay(timeMillis = 4000L)
-//                navigation.disableProgress()
-//            }
+            // end user logic for creating account goes here
         }
     }
 

--- a/feature/create-account/src/test/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountViewModelTest.kt
+++ b/feature/create-account/src/test/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountViewModelTest.kt
@@ -3,9 +3,16 @@ package com.nicholas.rutherford.track.my.shot.feature.create.account
 import android.app.Application
 import com.nicholas.rutherford.track.my.shot.firebase.create.CreateFirebaseUserInfo
 import com.nicholas.rutherford.track.my.shot.helper.network.Network
-import io.mockk.every
+import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -24,9 +31,20 @@ class CreateAccountViewModelTest {
 
     private val state = CreateAccountState(username = null, email = null, password = null)
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val dispatcher = StandardTestDispatcher()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
     @BeforeEach
     fun beforeEach() {
+        Dispatchers.setMain(dispatcher)
         viewModel = CreateAccountViewModel(navigation = navigation, application = application, network = network, createFirebaseUserInfo = createFirebaseUserInfo)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @AfterEach
+    fun afterEach() {
+        Dispatchers.resetMain()
     }
 
     @Test
@@ -216,18 +234,24 @@ class CreateAccountViewModelTest {
     @Nested
     inner class ValidateFields {
 
+        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
-        fun `when isDeviceConnectedToInternet is set to true should navigate to show alert`() {
-            every { network.isDeviceConnectedToInternet() } returns false
+        fun `when isDeviceConnectedToInternet is set to true should navigate to show alert`() = runTest {
+            Dispatchers.setMain(dispatcher)
+
+            coEvery { network.isDeviceConnectedToInternet() } returns false
 
             viewModel.validateFields()
 
             verify { navigation.alert(alert = any()) }
         }
 
+        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
-        fun `when isTwoOrMoreFieldsEmptyOrNull is set to true should navigate to show alert`() {
-            every { network.isDeviceConnectedToInternet() } returns true
+        fun `when isTwoOrMoreFieldsEmptyOrNull is set to true should navigate to show alert`() = runTest {
+            Dispatchers.setMain(dispatcher)
+
+            coEvery { network.isDeviceConnectedToInternet() } returns true
 
             viewModel.isTwoOrMoreFieldsEmptyOrNull = false
             viewModel.isUsernameEmptyOrNull = false
@@ -240,9 +264,12 @@ class CreateAccountViewModelTest {
             verify { navigation.alert(alert = any()) }
         }
 
+        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
-        fun `when isUsernamEmptyOrNull is set to true should navigate to show alert`() {
-            every { network.isDeviceConnectedToInternet() } returns true
+        fun `when isUsernamEmptyOrNull is set to true should navigate to show alert`() = runTest {
+            Dispatchers.setMain(dispatcher)
+
+            coEvery { network.isDeviceConnectedToInternet() } returns true
 
             viewModel.isTwoOrMoreFieldsEmptyOrNull = false
             viewModel.isUsernameEmptyOrNull = true
@@ -254,9 +281,12 @@ class CreateAccountViewModelTest {
             verify { navigation.alert(alert = any()) }
         }
 
+        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
-        fun `when isEmailEmptyOrNull is set to true should navigate to show alert`() {
-            every { network.isDeviceConnectedToInternet() } returns true
+        fun `when isEmailEmptyOrNull is set to true should navigate to show alert`() = runTest {
+            Dispatchers.setMain(dispatcher)
+
+            coEvery { network.isDeviceConnectedToInternet() } returns true
 
             viewModel.isTwoOrMoreFieldsEmptyOrNull = false
             viewModel.isUsernameEmptyOrNull = false
@@ -268,9 +298,12 @@ class CreateAccountViewModelTest {
             verify { navigation.alert(alert = any()) }
         }
 
+        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
-        fun `when isPasswordEmptyOrNull is set to true should navigate to show alert`() {
-            every { network.isDeviceConnectedToInternet() } returns true
+        fun `when isPasswordEmptyOrNull is set to true should navigate to show alert`() = runTest {
+            Dispatchers.setMain(dispatcher)
+
+            coEvery { network.isDeviceConnectedToInternet() } returns true
 
             viewModel.isTwoOrMoreFieldsEmptyOrNull = false
             viewModel.isUsernameEmptyOrNull = false
@@ -282,9 +315,12 @@ class CreateAccountViewModelTest {
             verify { navigation.alert(alert = any()) }
         }
 
+        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
-        fun `when all validation fields are set to false should not navigate to show alert`() {
-            every { network.isDeviceConnectedToInternet() } returns true
+        fun `when all validation fields are set to false should not navigate to show alert`() = runTest {
+            Dispatchers.setMain(dispatcher)
+
+            coEvery { network.isDeviceConnectedToInternet() } returns true
 
             viewModel.isTwoOrMoreFieldsEmptyOrNull = false
             viewModel.isUsernameEmptyOrNull = false

--- a/helper/network/build.gradle.kts
+++ b/helper/network/build.gradle.kts
@@ -62,6 +62,8 @@ android {
 dependencies {
     api(project(path = ":base-resources"))
 
+    implementation(Dependencies.Coroutine.jvm)
+
     testImplementation(Dependencies.Coroutine.test)
 
     testImplementation(Dependencies.Junit.Jupiter.api)

--- a/helper/network/src/main/java/com/nicholas/rutherford/track/my/shot/helper/network/Network.kt
+++ b/helper/network/src/main/java/com/nicholas/rutherford/track/my/shot/helper/network/Network.kt
@@ -1,5 +1,5 @@
 package com.nicholas.rutherford.track.my.shot.helper.network
 
 interface Network {
-    fun isDeviceConnectedToInternet(): Boolean
+    suspend fun isDeviceConnectedToInternet(): Boolean
 }

--- a/helper/network/src/main/java/com/nicholas/rutherford/track/my/shot/helper/network/NetworkImpl.kt
+++ b/helper/network/src/main/java/com/nicholas/rutherford/track/my/shot/helper/network/NetworkImpl.kt
@@ -1,17 +1,28 @@
 package com.nicholas.rutherford.track.my.shot.helper.network
 
-import android.app.Application
-import com.nicholas.rutherford.track.my.shot.feature.splash.StringsIds
-import java.net.InetAddress
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.Socket
 
-class NetworkImpl(private val application: Application) : Network {
+const val HOST_NAME = "8.8.8.8"
+const val PORT = 53
+const val TIMEOUT_MS = 1500
 
-    override fun isDeviceConnectedToInternet(): Boolean {
-        return try {
-            !InetAddress.getByName(application.getString(StringsIds.googleCom)).equals(application.getString(StringsIds.empty))
-        } catch (exception: Exception) {
-            println(exception.stackTrace)
-            false
+class NetworkImpl : Network {
+
+    @OptIn(DelicateCoroutinesApi::class)
+    override suspend fun isDeviceConnectedToInternet(): Boolean = GlobalScope.async {
+        try {
+            val sock = Socket()
+            return@async runCatching {
+                sock.connect(InetSocketAddress(HOST_NAME, PORT), TIMEOUT_MS)
+                sock.close()
+            }.isSuccess
+        } catch (e: IOException) {
+            return@async false
         }
-    }
+    }.await()
 }

--- a/helper/network/src/test/java/com/nicholas/rutherford/track/my/shot/helper/network/NetworkImplTest.kt
+++ b/helper/network/src/test/java/com/nicholas/rutherford/track/my/shot/helper/network/NetworkImplTest.kt
@@ -1,32 +1,66 @@
 package com.nicholas.rutherford.track.my.shot.helper.network
 
-import android.app.Application
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.net.UnknownHostException
 
 class NetworkImplTest {
 
-    private val application = Application()
-
     lateinit var networkImpl: NetworkImpl
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val dispatcher = StandardTestDispatcher()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
     @BeforeEach
     fun beforeEach() {
-        networkImpl = NetworkImpl(application = application)
+        Dispatchers.setMain(dispatcher)
+        networkImpl = NetworkImpl()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @AfterEach
+    fun afterEach() {
+        Dispatchers.resetMain()
     }
 
     @Nested
-    inner class IsDeviceConnectedToInternet() {
+    inner class consts {
 
         @Test
-        @Throws(UnknownHostException::class)
-        fun `should return back false if InetAddress throws back a unknown expection`() {
-            Assertions.assertEquals(false, networkImpl.isDeviceConnectedToInternet())
+        fun `host name`() {
+            Assertions.assertEquals("8.8.8.8", HOST_NAME)
         }
 
-        // todo -> add more tests for InetAddresses in the future
+        @Test
+        fun `port`() {
+            Assertions.assertEquals(53, PORT)
+        }
+
+        @Test
+        fun `timeout ms`() {
+            Assertions.assertEquals(1500, TIMEOUT_MS)
+        }
+    }
+
+    // todo add tests
+    @Nested
+    inner class IsDeviceConnectedToInternet() {
+
+//        @OptIn(ExperimentalCoroutinesApi::class)
+//        @Test
+//        @Throws(IOException::class)
+//        fun `should return back false if InetAddress throws back a unknown expection`() = runTest {
+//            Dispatchers.setMain(dispatcher)
+//
+//            Assertions.assertEquals(false, networkImpl.isDeviceConnectedToInternet())
+//        }
     }
 }

--- a/navigation/src/main/java/com/nicholas/rutherford/track/my/shot/navigation/NavigationComponent.kt
+++ b/navigation/src/main/java/com/nicholas/rutherford/track/my/shot/navigation/NavigationComponent.kt
@@ -99,6 +99,7 @@ fun NavigationComponent(
     alert?.let { newAlert ->
         AlertDialog(
             onDismissClicked = {
+                navigator.alert(alertAction = null)
                 alert = null
                 newAlert.onDismissClicked.invoke()
             },
@@ -106,6 +107,7 @@ fun NavigationComponent(
             confirmButton = newAlert.confirmButton?.let { confirmButton ->
                 AlertConfirmAndDismissButton(
                     onButtonClicked = {
+                        navigator.alert(alertAction = null)
                         alert = null
                         confirmButton.onButtonClicked.invoke()
                     },
@@ -115,6 +117,7 @@ fun NavigationComponent(
             dismissButton = newAlert.dismissButton?.let { dismissButton ->
                 AlertConfirmAndDismissButton(
                     onButtonClicked = {
+                        navigator.alert(alertAction = null)
                         alert = null
                         dismissButton.onButtonClicked.invoke()
                     },
@@ -129,6 +132,7 @@ fun NavigationComponent(
         ProgressDialog(
             onDismissClicked = {
                 if (newProgress.shouldBeAbleToBeDismissed) {
+                    navigator.progress(progressAction = null)
                     progress = null
                 }
                 newProgress.onDismissClicked.invoke()


### PR DESCRIPTION
### Trello
- N/A 

### Issues
- We have a issue with the alert and progress mask only shows up one time via a screen 
- Issue were the `isDeviceConnectedToInternet` defined in `:helper:network` module sometimes doesn't actually return back a valid result. 

### Proposed Changes
- Fix the alert and progress mask issue by actually setting the value of the alert and progress mask to null after the user closes both of them. This is so that way it can record a new event. 
- Rework the `isDeviceConnectedToInternet` by introducing sockets to attempt to connect to an actual network which is a more valid function call. 

### TO-DO
- Add unit tests for `NetworkImpl` made myself a new task here for it: https://trello.com/c/18MPLEqC/88-add-unit-tests-to-networkimpl-class

### Additional Info
- N/A 
