### PR TITLE
nick: Add firebase realtime database method to create object for users info when creating a account

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -108,6 +108,7 @@ dependencies {
 
     implementation(Dependencies.Firebase.authKtx)
     implementation(Dependencies.Firebase.bom)
+    implementation(Dependencies.Firebase.databaseKtx)
 
     implementation(Dependencies.Koin.core)
 

--- a/app/src/main/java/com/nicholas/rutherford/track/my/shot/AppModule.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/my/shot/AppModule.kt
@@ -1,6 +1,7 @@
 package com.nicholas.rutherford.track.my.shot
 
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.database.FirebaseDatabase
 import com.nicholas.rutherford.track.my.shot.app.center.AppCenter
 import com.nicholas.rutherford.track.my.shot.app.center.AppCenterImpl
 import com.nicholas.rutherford.track.my.shot.build.type.BuildType
@@ -36,8 +37,11 @@ class AppModule {
         single {
             FirebaseAuth.getInstance()
         }
+        single {
+            FirebaseDatabase.getInstance()
+        }
         single<CreateFirebaseUserInfo> {
-            CreateFirebaseUserInfoImpl(firebaseAuth = get())
+            CreateFirebaseUserInfoImpl(firebaseAuth = get(), firebaseDatabase = get())
         }
         single<Network> {
             NetworkImpl()

--- a/app/src/test/java/com/nicholas/rutherford/track/my/shot/MyApplicationTest.kt
+++ b/app/src/test/java/com/nicholas/rutherford/track/my/shot/MyApplicationTest.kt
@@ -1,6 +1,7 @@
 package com.nicholas.rutherford.track.my.shot
 
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.database.FirebaseDatabase
 import com.nicholas.rutherford.track.my.shot.app.center.AppCenter
 import com.nicholas.rutherford.track.my.shot.build.type.BuildType
 import com.nicholas.rutherford.track.my.shot.feature.home.HomeViewModel
@@ -30,6 +31,8 @@ import kotlin.test.assertNotNull
 class MyApplicationTest : KoinTest {
 
     private val firebaseAuth: FirebaseAuth by inject()
+    private val firebaseDatabase: FirebaseDatabase by inject()
+
     private val createFirebaseUserInfo: CreateFirebaseUserInfo by inject()
 
     private val network: Network by inject()
@@ -71,6 +74,8 @@ class MyApplicationTest : KoinTest {
         myApplication.startKoinOnCreate()
 
         assertNotNull(firebaseAuth)
+        assertNotNull(firebaseDatabase)
+
         assertNotNull(createFirebaseUserInfo)
 
         assertNotNull(network)

--- a/app/src/test/java/com/nicholas/rutherford/track/my/shot/MyApplicationTest.kt
+++ b/app/src/test/java/com/nicholas/rutherford/track/my/shot/MyApplicationTest.kt
@@ -69,7 +69,10 @@ class MyApplicationTest : KoinTest {
     @Test
     fun `start koin on create should inject modules with instances as not null`() {
         mockkStatic(FirebaseAuth::class)
+        mockkStatic(FirebaseDatabase::class)
+
         every { FirebaseAuth.getInstance() } returns mockk(relaxed = true)
+        every { FirebaseDatabase.getInstance() } returns mockk(relaxed = true)
 
         myApplication.startKoinOnCreate()
 

--- a/base-resources/src/main/java/com/nicholas/rutherford/track/my/shot/feature/splash/StringsIds.kt
+++ b/base-resources/src/main/java/com/nicholas/rutherford/track/my/shot/feature/splash/StringsIds.kt
@@ -13,7 +13,6 @@ object StringsIds {
     val emptyFields = R.string.empty_fields
     val emailIsRequiredPleaseEnterAEmailToCreateAAccount = R.string.email_is_required_please_enter_a_email_to_create_a_account
     val email = R.string.email
-    val googleCom = R.string.google_com
     val gotIt = R.string.got_it
     val login = R.string.login
     val loginIconDescription = R.string.login_icon_description

--- a/base-resources/src/main/res/values/strings.xml
+++ b/base-resources/src/main/res/values/strings.xml
@@ -10,7 +10,6 @@
     <string name="empty_field">Empty Field</string>
     <string name="empty_fields">Empty Fields</string>
     <string name="email">Email</string>
-    <string name="google_com" translatable="false">google.com</string>
     <string name="got_it">Got It</string>
     <string name="login">Login</string>
     <string name="login_icon_description">This is a login image for the login screen</string>

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -45,7 +45,7 @@ object Dependencies {
     object Firebase {
         const val authKtx = "com.google.firebase:firebase-auth-ktx:${Versions.Dependencies.Firebase.authKtx}"
         const val bom = "com.google.firebase:firebase-bom:${Versions.Dependencies.Firebase.bom}"
-        const val databaseKts = "com.google.firebase.firebase-database-ktx"
+        const val databaseKtx = "com.google.firebase:firebase-database-ktx:${Versions.Dependencies.Firebase.ktx}"
     }
 
     object Junit {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -42,6 +42,7 @@ object Versions {
         object Firebase {
             const val authKtx = "21.1.0"
             const val bom = "31.0.3"
+            const val ktx = "20.1.0"
         }
 
         object JunitJupiter {

--- a/data-test/account-info/src/main/java/com/nicholas/rutherford/track/my/shot/data/test/account/info/TestCreateAccountFirebaseAuthResponse.kt
+++ b/data-test/account-info/src/main/java/com/nicholas/rutherford/track/my/shot/data/test/account/info/TestCreateAccountFirebaseAuthResponse.kt
@@ -1,10 +1,10 @@
 package com.nicholas.rutherford.track.my.shot.data.test.account.info
 
-import com.nicholas.rutherford.track.my.shot.account.info.CreateAccountResponse
+import com.nicholas.rutherford.track.my.shot.account.info.CreateAccountFirebaseAuthResponse
 
-class TestCreateAccountResponse {
-    fun create(): CreateAccountResponse {
-        return CreateAccountResponse(
+class TestCreateAccountFirebaseAuthResponse {
+    fun create(): CreateAccountFirebaseAuthResponse {
+        return CreateAccountFirebaseAuthResponse(
             isSuccessful = IS_SUCCESSFUL,
             username = USERNAME,
             isNewUser = IS_NEW_USER,

--- a/data-test/account-info/src/main/java/com/nicholas/rutherford/track/my/shot/data/test/account/info/TestCreateAccountFirebaseRealtimeDatabaseResult.kt
+++ b/data-test/account-info/src/main/java/com/nicholas/rutherford/track/my/shot/data/test/account/info/TestCreateAccountFirebaseRealtimeDatabaseResult.kt
@@ -1,0 +1,15 @@
+package com.nicholas.rutherford.track.my.shot.data.test.account.info
+
+import com.nicholas.rutherford.track.my.shot.account.info.CreateAccountFirebaseRealtimeDatabaseResult
+
+class TestCreateAccountFirebaseRealtimeDatabaseResult {
+    fun create(): CreateAccountFirebaseRealtimeDatabaseResult {
+        return CreateAccountFirebaseRealtimeDatabaseResult(
+            username = USER_NAME,
+            email = EMAIL
+        )
+    }
+}
+
+const val USER_NAME = "boomyNicholasR"
+const val EMAIL = "testEmail@yahoo.com"

--- a/data/account-info/src/main/java/com/nicholas/rutherford/track/my/shot/account/info/CreateAccountFirebaseAuthResponse.kt
+++ b/data/account-info/src/main/java/com/nicholas/rutherford/track/my/shot/account/info/CreateAccountFirebaseAuthResponse.kt
@@ -1,6 +1,6 @@
 package com.nicholas.rutherford.track.my.shot.account.info
 
-data class CreateAccountResponse(
+data class CreateAccountFirebaseAuthResponse(
     val isSuccessful: Boolean = false,
     val username: String? = null,
     val isNewUser: Boolean? = null,

--- a/data/account-info/src/main/java/com/nicholas/rutherford/track/my/shot/account/info/CreateAccountFirebaseRealtimeDatabaseResult.kt
+++ b/data/account-info/src/main/java/com/nicholas/rutherford/track/my/shot/account/info/CreateAccountFirebaseRealtimeDatabaseResult.kt
@@ -1,0 +1,6 @@
+package com.nicholas.rutherford.track.my.shot.account.info
+
+data class CreateAccountFirebaseRealtimeDatabaseResult(
+    val username: String,
+    val email: String
+)

--- a/firebase/create/build.gradle.kts
+++ b/firebase/create/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
 
     implementation(Dependencies.Firebase.authKtx)
     implementation(Dependencies.Firebase.bom)
+    implementation(Dependencies.Firebase.databaseKtx)
 
     testImplementation(Dependencies.Coroutine.test)
 

--- a/firebase/create/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfo.kt
+++ b/firebase/create/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfo.kt
@@ -5,4 +5,5 @@ import kotlinx.coroutines.flow.Flow
 
 interface CreateFirebaseUserInfo {
     fun attemptToCreateAccountFirebaseAuthResponseFlow(email: String, password: String): Flow<CreateAccountFirebaseAuthResponse>
+    fun attemptToCreateAccountFirebaseRealTimeDatabaseResponseFlow(userName: String, email: String): Flow<Boolean>
 }

--- a/firebase/create/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfo.kt
+++ b/firebase/create/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfo.kt
@@ -1,8 +1,8 @@
 package com.nicholas.rutherford.track.my.shot.firebase.create
 
-import com.nicholas.rutherford.track.my.shot.account.info.CreateAccountResponse
+import com.nicholas.rutherford.track.my.shot.account.info.CreateAccountFirebaseAuthResponse
 import kotlinx.coroutines.flow.Flow
 
 interface CreateFirebaseUserInfo {
-    fun attemptToCreateAccountResponseFlow(email: String, password: String): Flow<CreateAccountResponse>
+    fun attemptToCreateAccountFirebaseAuthResponseFlow(email: String, password: String): Flow<CreateAccountFirebaseAuthResponse>
 }

--- a/firebase/create/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfoImpl.kt
+++ b/firebase/create/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfoImpl.kt
@@ -1,12 +1,22 @@
 package com.nicholas.rutherford.track.my.shot.firebase.create
 
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.database.FirebaseDatabase
 import com.nicholas.rutherford.track.my.shot.account.info.CreateAccountFirebaseAuthResponse
+import com.nicholas.rutherford.track.my.shot.account.info.CreateAccountFirebaseRealtimeDatabaseResult
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
-class CreateFirebaseUserInfoImpl(private val firebaseAuth: FirebaseAuth) : CreateFirebaseUserInfo {
+const val USERS_PATH = "users"
+const val USERNAME = "userName"
+const val EMAIL = "email"
+const val USER_INFO = "userInfo"
+
+class CreateFirebaseUserInfoImpl(private val firebaseAuth: FirebaseAuth, firebaseDatabase: FirebaseDatabase) : CreateFirebaseUserInfo {
+
+    private val userReference = firebaseDatabase.getReference(USERS_PATH)
+
     override fun attemptToCreateAccountFirebaseAuthResponseFlow(email: String, password: String): Flow<CreateAccountFirebaseAuthResponse> {
         return callbackFlow {
             firebaseAuth.createUserWithEmailAndPassword(email, password)
@@ -19,6 +29,22 @@ class CreateFirebaseUserInfoImpl(private val firebaseAuth: FirebaseAuth) : Creat
                             exception = task.exception
                         )
                     )
+                }
+            awaitClose()
+        }
+    }
+
+    override fun attemptToCreateAccountFirebaseRealTimeDatabaseResponseFlow(userName: String, email: String): Flow<Boolean> {
+        return callbackFlow {
+            val createAccountResult = CreateAccountFirebaseRealtimeDatabaseResult(username = userName, email = email)
+            val values = hashMapOf<String, String>()
+
+            values[USERNAME] = createAccountResult.username
+            values[EMAIL] = createAccountResult.email
+
+            userReference.child(USER_INFO).push().setValue(values)
+                .addOnCompleteListener { task ->
+                    trySend(task.isSuccessful)
                 }
             awaitClose()
         }

--- a/firebase/create/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfoImpl.kt
+++ b/firebase/create/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfoImpl.kt
@@ -1,18 +1,18 @@
 package com.nicholas.rutherford.track.my.shot.firebase.create
 
 import com.google.firebase.auth.FirebaseAuth
-import com.nicholas.rutherford.track.my.shot.account.info.CreateAccountResponse
+import com.nicholas.rutherford.track.my.shot.account.info.CreateAccountFirebaseAuthResponse
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
 class CreateFirebaseUserInfoImpl(private val firebaseAuth: FirebaseAuth) : CreateFirebaseUserInfo {
-    override fun attemptToCreateAccountResponseFlow(email: String, password: String): Flow<CreateAccountResponse> {
+    override fun attemptToCreateAccountFirebaseAuthResponseFlow(email: String, password: String): Flow<CreateAccountFirebaseAuthResponse> {
         return callbackFlow {
             firebaseAuth.createUserWithEmailAndPassword(email, password)
                 .addOnCompleteListener { task ->
                     trySend(
-                        CreateAccountResponse(
+                        CreateAccountFirebaseAuthResponse(
                             isSuccessful = task.isSuccessful,
                             username = task.result?.additionalUserInfo?.username,
                             isNewUser = task.result?.additionalUserInfo?.isNewUser,

--- a/firebase/create/src/test/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfoImplTest.kt
+++ b/firebase/create/src/test/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfoImplTest.kt
@@ -5,7 +5,9 @@ import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.database.FirebaseDatabase
 import com.nicholas.rutherford.track.my.shot.data.test.account.info.TestCreateAccountFirebaseAuthResponse
+import com.nicholas.rutherford.track.my.shot.data.test.account.info.TestCreateAccountFirebaseRealtimeDatabaseResult
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -15,6 +17,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class CreateFirebaseUserInfoImplTest {
@@ -22,15 +25,41 @@ class CreateFirebaseUserInfoImplTest {
     lateinit var createFirebaseUserInfoImpl: CreateFirebaseUserInfoImpl
 
     val firebaseAuth = mockk<FirebaseAuth>(relaxed = true)
+    val firebaseDatabase = mockk<FirebaseDatabase>(relaxed = true)
 
     val createAccountResponse = TestCreateAccountFirebaseAuthResponse().create()
+    val createAccountResult = TestCreateAccountFirebaseRealtimeDatabaseResult().create()
 
     val testEmail = "testemail@yahoo.com"
     val testPassword = "passwordTest112"
 
     @BeforeEach
     fun beforeEach() {
-        createFirebaseUserInfoImpl = CreateFirebaseUserInfoImpl(firebaseAuth = firebaseAuth)
+        createFirebaseUserInfoImpl = CreateFirebaseUserInfoImpl(firebaseAuth = firebaseAuth, firebaseDatabase = firebaseDatabase)
+    }
+
+    @Nested
+    inner class Consts {
+
+        @Test
+        fun `users path`() {
+            Assertions.assertEquals("users", USERS_PATH)
+        }
+
+        @Test
+        fun `user name`() {
+            Assertions.assertEquals("userName", USERNAME)
+        }
+
+        @Test
+        fun email() {
+            Assertions.assertEquals("email", EMAIL)
+        }
+
+        @Test
+        fun `user info`() {
+            Assertions.assertEquals("userInfo", USER_INFO)
+        }
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -54,5 +83,30 @@ class CreateFirebaseUserInfoImplTest {
         val createFirebaseUserInfo = createFirebaseUserInfoImpl.attemptToCreateAccountFirebaseAuthResponseFlow(testEmail, testPassword).first()
 
         Assertions.assertEquals(createAccountResponse.copy(exception = null), createFirebaseUserInfo)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `when add on complete listener is executed should set flow to true when isSuccessful returns back true`() = runTest {
+        val mockTaskVoidResult = mockk<Task<Void>>()
+        val slot = slot<OnCompleteListener<Void>>()
+
+        val values = hashMapOf<String, String>()
+
+        values[USERNAME] = createAccountResult.username
+        values[EMAIL] = createAccountResult.email
+
+        mockkStatic(Tasks::class)
+
+        every { mockTaskVoidResult.isSuccessful } returns false
+
+        every { firebaseDatabase.getReference(USERS_PATH).child(USER_INFO).push().setValue(values).addOnCompleteListener(capture(slot)) } answers {
+            slot.captured.onComplete(mockTaskVoidResult)
+            mockTaskVoidResult
+        }
+
+        val value = createFirebaseUserInfoImpl.attemptToCreateAccountFirebaseRealTimeDatabaseResponseFlow(userName = createAccountResult.username, email = createAccountResult.email).first()
+
+        Assertions.assertEquals(false, value)
     }
 }

--- a/firebase/create/src/test/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfoImplTest.kt
+++ b/firebase/create/src/test/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfoImplTest.kt
@@ -5,7 +5,7 @@ import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth
-import com.nicholas.rutherford.track.my.shot.data.test.account.info.TestCreateAccountResponse
+import com.nicholas.rutherford.track.my.shot.data.test.account.info.TestCreateAccountFirebaseAuthResponse
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -23,7 +23,7 @@ class CreateFirebaseUserInfoImplTest {
 
     val firebaseAuth = mockk<FirebaseAuth>(relaxed = true)
 
-    val createAccountResponse = TestCreateAccountResponse().create()
+    val createAccountResponse = TestCreateAccountFirebaseAuthResponse().create()
 
     val testEmail = "testemail@yahoo.com"
     val testPassword = "passwordTest112"
@@ -51,7 +51,7 @@ class CreateFirebaseUserInfoImplTest {
             mockTaskAuthResult
         }
 
-        val createFirebaseUserInfo = createFirebaseUserInfoImpl.attemptToCreateAccountResponseFlow(testEmail, testPassword).first()
+        val createFirebaseUserInfo = createFirebaseUserInfoImpl.attemptToCreateAccountFirebaseAuthResponseFlow(testEmail, testPassword).first()
 
         Assertions.assertEquals(createAccountResponse.copy(exception = null), createFirebaseUserInfo)
     }


### PR DESCRIPTION
### Trello
https://trello.com/c/sZtuewUk/43-tie-in-firebase-creation-of-a-account-to-app-ability-to-create-profile-via-ui

### Issues
- We currently don't have a realtime database method to ensure that when a user creates their account via email and password; that they actually attempt to also create a realtime database entry. This entry for now should contain the user username and email(password isn't saved due to security issues). 

### Proposed Changes
- Create said method 
- Add tests 

### TO-DO
- Since we have everything we need, finish the view model process to ensure we can complete the work flow. 

### Additional Info
- N/A 