### PR TITLE
nick: Change Realtime DB naming from `userInfo` to `accountInfo` 

### DIFF
--- a/firebase/create/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfoImpl.kt
+++ b/firebase/create/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfoImpl.kt
@@ -8,10 +8,10 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
+const val ACCOUNT_INFO = "accountInfo"
+const val EMAIL = "email"
 const val USERS_PATH = "users"
 const val USERNAME = "userName"
-const val EMAIL = "email"
-const val USER_INFO = "userInfo"
 
 class CreateFirebaseUserInfoImpl(private val firebaseAuth: FirebaseAuth, firebaseDatabase: FirebaseDatabase) : CreateFirebaseUserInfo {
 
@@ -42,7 +42,7 @@ class CreateFirebaseUserInfoImpl(private val firebaseAuth: FirebaseAuth, firebas
             values[USERNAME] = createAccountResult.username
             values[EMAIL] = createAccountResult.email
 
-            userReference.child(USER_INFO).push().setValue(values)
+            userReference.child(ACCOUNT_INFO).push().setValue(values)
                 .addOnCompleteListener { task ->
                     trySend(task.isSuccessful)
                 }

--- a/firebase/create/src/test/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfoImplTest.kt
+++ b/firebase/create/src/test/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfoImplTest.kt
@@ -39,7 +39,17 @@ class CreateFirebaseUserInfoImplTest {
     }
 
     @Nested
-    inner class Consts {
+    inner class Constants {
+
+        @Test
+        fun `account info`() {
+            Assertions.assertEquals("accountInfo", ACCOUNT_INFO)
+        }
+
+        @Test
+        fun email() {
+            Assertions.assertEquals("email", EMAIL)
+        }
 
         @Test
         fun `users path`() {
@@ -49,16 +59,6 @@ class CreateFirebaseUserInfoImplTest {
         @Test
         fun `user name`() {
             Assertions.assertEquals("userName", USERNAME)
-        }
-
-        @Test
-        fun email() {
-            Assertions.assertEquals("email", EMAIL)
-        }
-
-        @Test
-        fun `user info`() {
-            Assertions.assertEquals("userInfo", USER_INFO)
         }
     }
 
@@ -100,7 +100,7 @@ class CreateFirebaseUserInfoImplTest {
 
         every { mockTaskVoidResult.isSuccessful } returns false
 
-        every { firebaseDatabase.getReference(USERS_PATH).child(USER_INFO).push().setValue(values).addOnCompleteListener(capture(slot)) } answers {
+        every { firebaseDatabase.getReference(USERS_PATH).child(ACCOUNT_INFO).push().setValue(values).addOnCompleteListener(capture(slot)) } answers {
             slot.captured.onComplete(mockTaskVoidResult)
             mockTaskVoidResult
         }


### PR DESCRIPTION
### Trello
- N/A 

### Issues
- We want to change the naming from `userInfo` to `accountInfo` for where we save the users `email` and `username`. 

### Proposed Changes
- Go ahead and make the naming change 
- Update tests

### TO-DO
- N/A 