### PR TITLE
nick: Introduce a getAccountInfoFlowByEmail realtime database method

### DIFF
--- a/app/src/main/java/com/nicholas/rutherford/track/my/shot/AppModule.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/my/shot/AppModule.kt
@@ -78,7 +78,7 @@ class AppModule {
             ExistingUserFirebaseImpl(firebaseAuth = get())
         }
         single<ReadFirebaseUserInfo> {
-            ReadFirebaseUserInfoImpl(firebaseAuth = get())
+            ReadFirebaseUserInfoImpl(firebaseAuth = get(), firebaseDatabase = get())
         }
         single<Network> {
             NetworkImpl()

--- a/data-test/account-info/src/main/java/com/nicholas/rutherford/track/my/shot/data/test/account/info/realtime/TestAccountInfoRealTimeResponse.kt
+++ b/data-test/account-info/src/main/java/com/nicholas/rutherford/track/my/shot/data/test/account/info/realtime/TestAccountInfoRealTimeResponse.kt
@@ -1,0 +1,16 @@
+package com.nicholas.rutherford.track.my.shot.data.test.account.info.realtime
+
+import com.nicholas.rutherford.track.my.shot.account.info.realtime.AccountInfoRealtimeResponse
+
+class TestAccountInfoRealTimeResponse {
+
+    fun create(): AccountInfoRealtimeResponse {
+        return AccountInfoRealtimeResponse(
+            username = USER_NAME_ACCOUNT_INFO_REALTIME_RESPONSE,
+            email = EMAIL_ACCOUNT_INFO_REALTIME_RESPONSE
+        )
+    }
+}
+
+const val USER_NAME_ACCOUNT_INFO_REALTIME_RESPONSE = "boomyNicholasR"
+const val EMAIL_ACCOUNT_INFO_REALTIME_RESPONSE = "testEmail@yahoo.com"

--- a/data-test/account-info/src/main/java/com/nicholas/rutherford/track/my/shot/data/test/account/info/realtime/TestCreateAccountFirebaseRealtimeDatabaseResult.kt
+++ b/data-test/account-info/src/main/java/com/nicholas/rutherford/track/my/shot/data/test/account/info/realtime/TestCreateAccountFirebaseRealtimeDatabaseResult.kt
@@ -1,6 +1,6 @@
-package com.nicholas.rutherford.track.my.shot.data.test.account.info
+package com.nicholas.rutherford.track.my.shot.data.test.account.info.realtime
 
-import com.nicholas.rutherford.track.my.shot.account.info.CreateAccountFirebaseRealtimeDatabaseResult
+import com.nicholas.rutherford.track.my.shot.account.info.realtime.CreateAccountFirebaseRealtimeDatabaseResult
 
 class TestCreateAccountFirebaseRealtimeDatabaseResult {
     fun create(): CreateAccountFirebaseRealtimeDatabaseResult {

--- a/data/account-info/src/main/java/com/nicholas/rutherford/track/my/shot/account/info/realtime/AccountInfoRealtimeResponse.kt
+++ b/data/account-info/src/main/java/com/nicholas/rutherford/track/my/shot/account/info/realtime/AccountInfoRealtimeResponse.kt
@@ -1,0 +1,6 @@
+package com.nicholas.rutherford.track.my.shot.account.info.realtime
+
+data class AccountInfoRealtimeResponse(
+    val username: String = "",
+    val email: String = ""
+)

--- a/data/account-info/src/main/java/com/nicholas/rutherford/track/my/shot/account/info/realtime/CreateAccountFirebaseRealtimeDatabaseResult.kt
+++ b/data/account-info/src/main/java/com/nicholas/rutherford/track/my/shot/account/info/realtime/CreateAccountFirebaseRealtimeDatabaseResult.kt
@@ -1,4 +1,4 @@
-package com.nicholas.rutherford.track.my.shot.account.info
+package com.nicholas.rutherford.track.my.shot.account.info.realtime
 
 data class CreateAccountFirebaseRealtimeDatabaseResult(
     val username: String,

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/authentication/AuthenticationViewModel.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/authentication/AuthenticationViewModel.kt
@@ -63,7 +63,7 @@ class AuthenticationViewModel(
     }
 
     private suspend fun collectIfUserIsVerifiedAndAttemptToCreateAccount() {
-        readFirebaseUserInfo.isEmailVerified().collectLatest { isVerified ->
+        readFirebaseUserInfo.isEmailVerifiedFlow().collectLatest { isVerified ->
             if (isVerified) {
                 safeLet(username, email) { usernameArgument, emailArgument ->
                     navigation.enableProgress(progress = Progress(onDismissClicked = {}))

--- a/feature/create-account/src/test/java/com/nicholas/rutherford/track/my/shot/feature/create/account/AuthenticationViewModelTest.kt
+++ b/feature/create-account/src/test/java/com/nicholas/rutherford/track/my/shot/feature/create/account/AuthenticationViewModelTest.kt
@@ -136,7 +136,7 @@ class AuthenticationViewModelTest {
         @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when isEmailVerified returns back false should not attempt to create account`() = runTest {
-            every { readFirebaseUserInfo.isEmailVerified() } returns flowOf(value = false)
+            every { readFirebaseUserInfo.isEmailVerifiedFlow() } returns flowOf(value = false)
 
             viewModel.username = username
             viewModel.email = email
@@ -149,7 +149,7 @@ class AuthenticationViewModelTest {
         @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when isEmailVerified returns back true and username is null should not attempt to create account`() = runTest {
-            every { readFirebaseUserInfo.isEmailVerified() } returns flowOf(value = true)
+            every { readFirebaseUserInfo.isEmailVerifiedFlow() } returns flowOf(value = true)
 
             viewModel.username = null
             viewModel.email = email
@@ -162,7 +162,7 @@ class AuthenticationViewModelTest {
         @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when isEmailVerified returns back true and email is null should not attempt to create account`() = runTest {
-            every { readFirebaseUserInfo.isEmailVerified() } returns flowOf(value = true)
+            every { readFirebaseUserInfo.isEmailVerifiedFlow() } returns flowOf(value = true)
 
             viewModel.username = username
             viewModel.email = null
@@ -175,7 +175,7 @@ class AuthenticationViewModelTest {
         @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when isEmailVerified returns back true, fields are not null, with attemptToCreateAccountFirebase returns back not successful should show error creating account alert`() = runTest {
-            coEvery { readFirebaseUserInfo.isEmailVerified() } returns flowOf(value = true)
+            coEvery { readFirebaseUserInfo.isEmailVerifiedFlow() } returns flowOf(value = true)
             coEvery {
                 createFirebaseUserInfo.attemptToCreateAccountFirebaseRealTimeDatabaseResponseFlow(userName = username, email = email)
             } returns flowOf(value = false)
@@ -202,7 +202,7 @@ class AuthenticationViewModelTest {
         @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when isEmailVerified returns back true, fields are not null, with attemptToCreateAccountFirebase returns back successful should navigate to home`() = runTest {
-            coEvery { readFirebaseUserInfo.isEmailVerified() } returns flowOf(value = true)
+            coEvery { readFirebaseUserInfo.isEmailVerifiedFlow() } returns flowOf(value = true)
             coEvery {
                 createFirebaseUserInfo.attemptToCreateAccountFirebaseRealTimeDatabaseResponseFlow(userName = username, email = email)
             } returns flowOf(value = true)

--- a/feature/splash/src/main/java/com/nicholas/rutherford/track/my/shot/feature/splash/SplashViewModel.kt
+++ b/feature/splash/src/main/java/com/nicholas/rutherford/track/my/shot/feature/splash/SplashViewModel.kt
@@ -37,7 +37,7 @@ class SplashViewModel(
     }
 
     private suspend fun navigateToHomeLoginOrAuthentication() {
-        readFirebaseUserInfo.isLoggedIn().combine(readFirebaseUserInfo.isEmailVerified()) { isLoggedIn, isEmailVerified ->
+        readFirebaseUserInfo.isLoggedInFlow().combine(readFirebaseUserInfo.isEmailVerifiedFlow()) { isLoggedIn, isEmailVerified ->
             if (isLoggedIn) {
                 if (isEmailVerified && readSharedPreferences.accountHasBeenCreated()) {
                     delayAndNavigateToHomeOrLogin(isLoggedIn = true)

--- a/feature/splash/src/test/java/com/nicholas/rutherford/track/my/shot/feature/splash/SplashViewModelTest.kt
+++ b/feature/splash/src/test/java/com/nicholas/rutherford/track/my/shot/feature/splash/SplashViewModelTest.kt
@@ -92,8 +92,8 @@ class SplashViewModelTest {
                     every { readSharedPreferences.unverifiedUsername() } returns unverifiedUsername
                     every { readSharedPreferences.unverifiedEmail() } returns unverifiedEmail
 
-                    every { readFirebaseUserInfo.isLoggedIn() } returns flowOf(true)
-                    every { readFirebaseUserInfo.isEmailVerified() } returns flowOf(false)
+                    every { readFirebaseUserInfo.isLoggedInFlow() } returns flowOf(true)
+                    every { readFirebaseUserInfo.isEmailVerifiedFlow() } returns flowOf(false)
                     every { readSharedPreferences.accountHasBeenCreated() } returns true
 
                     Dispatchers.setMain(dispatcher)
@@ -115,8 +115,8 @@ class SplashViewModelTest {
                     every { readSharedPreferences.unverifiedUsername() } returns unverifiedUsername
                     every { readSharedPreferences.unverifiedEmail() } returns unverifiedEmail
 
-                    every { readFirebaseUserInfo.isLoggedIn() } returns flowOf(true)
-                    every { readFirebaseUserInfo.isEmailVerified() } returns flowOf(true)
+                    every { readFirebaseUserInfo.isLoggedInFlow() } returns flowOf(true)
+                    every { readFirebaseUserInfo.isEmailVerifiedFlow() } returns flowOf(true)
                     every { readSharedPreferences.accountHasBeenCreated() } returns false
 
                     Dispatchers.setMain(dispatcher)
@@ -135,7 +135,7 @@ class SplashViewModelTest {
             @Test
             fun `when isLoggedIn is set to false should not navigateToAuthentication`() =
                 runTest {
-                    every { readFirebaseUserInfo.isLoggedIn() } returns flowOf(false)
+                    every { readFirebaseUserInfo.isLoggedInFlow() } returns flowOf(false)
 
                     Dispatchers.setMain(dispatcher)
                     viewModel = SplashViewModel(
@@ -153,8 +153,8 @@ class SplashViewModelTest {
             @Test
             fun `when isLoggedIn is set to true, isEmailVerified set to true and accountHasBeenCreated is set to true should not call navigateToAuthentication`() =
                 runTest {
-                    every { readFirebaseUserInfo.isLoggedIn() } returns flowOf(true)
-                    every { readFirebaseUserInfo.isEmailVerified() } returns flowOf(true)
+                    every { readFirebaseUserInfo.isLoggedInFlow() } returns flowOf(true)
+                    every { readFirebaseUserInfo.isEmailVerifiedFlow() } returns flowOf(true)
                     every { readSharedPreferences.accountHasBeenCreated() } returns true
 
                     Dispatchers.setMain(dispatcher)
@@ -175,8 +175,8 @@ class SplashViewModelTest {
                 every { readSharedPreferences.unverifiedUsername() } returns null
                 every { readSharedPreferences.unverifiedEmail() } returns unverifiedEmail
 
-                every { readFirebaseUserInfo.isLoggedIn() } returns flowOf(true)
-                every { readFirebaseUserInfo.isEmailVerified() } returns flowOf(false)
+                every { readFirebaseUserInfo.isLoggedInFlow() } returns flowOf(true)
+                every { readFirebaseUserInfo.isEmailVerifiedFlow() } returns flowOf(false)
                 every { readSharedPreferences.accountHasBeenCreated() } returns true
 
                 Dispatchers.setMain(dispatcher)
@@ -197,8 +197,8 @@ class SplashViewModelTest {
                 every { readSharedPreferences.unverifiedUsername() } returns unverifiedUsername
                 every { readSharedPreferences.unverifiedEmail() } returns null
 
-                every { readFirebaseUserInfo.isLoggedIn() } returns flowOf(true)
-                every { readFirebaseUserInfo.isEmailVerified() } returns flowOf(false)
+                every { readFirebaseUserInfo.isLoggedInFlow() } returns flowOf(true)
+                every { readFirebaseUserInfo.isEmailVerifiedFlow() } returns flowOf(false)
                 every { readSharedPreferences.accountHasBeenCreated() } returns true
 
                 Dispatchers.setMain(dispatcher)
@@ -221,8 +221,8 @@ class SplashViewModelTest {
             @Test
             fun `should delay for 4 seconds and verifies that it calls navigateToLogin when isLoggedIn is set to false`() =
                 runTest {
-                    every { readFirebaseUserInfo.isLoggedIn() } returns flowOf(false)
-                    every { readFirebaseUserInfo.isEmailVerified() } returns flowOf(true)
+                    every { readFirebaseUserInfo.isLoggedInFlow() } returns flowOf(false)
+                    every { readFirebaseUserInfo.isEmailVerifiedFlow() } returns flowOf(true)
                     every { readSharedPreferences.accountHasBeenCreated() } returns false
 
                     Dispatchers.setMain(dispatcher)
@@ -242,8 +242,8 @@ class SplashViewModelTest {
             @Test
             fun `should delay for 4 seconds and verifies it calls navigateToHome when isLoggedIn is set to true`() =
                 runTest {
-                    every { readFirebaseUserInfo.isLoggedIn() } returns flowOf(true)
-                    every { readFirebaseUserInfo.isEmailVerified() } returns flowOf(true)
+                    every { readFirebaseUserInfo.isLoggedInFlow() } returns flowOf(true)
+                    every { readFirebaseUserInfo.isEmailVerifiedFlow() } returns flowOf(true)
                     every { readSharedPreferences.accountHasBeenCreated() } returns true
 
                     Dispatchers.setMain(dispatcher)

--- a/firebase/create/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfoImpl.kt
+++ b/firebase/create/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfoImpl.kt
@@ -3,7 +3,7 @@ package com.nicholas.rutherford.track.my.shot.firebase.create
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.FirebaseDatabase
 import com.nicholas.rutherford.track.my.shot.account.info.CreateAccountFirebaseAuthResponse
-import com.nicholas.rutherford.track.my.shot.account.info.CreateAccountFirebaseRealtimeDatabaseResult
+import com.nicholas.rutherford.track.my.shot.account.info.realtime.CreateAccountFirebaseRealtimeDatabaseResult
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow

--- a/firebase/create/src/test/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfoImplTest.kt
+++ b/firebase/create/src/test/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfoImplTest.kt
@@ -7,7 +7,7 @@ import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.FirebaseDatabase
 import com.nicholas.rutherford.track.my.shot.data.test.account.info.TestCreateAccountFirebaseAuthResponse
-import com.nicholas.rutherford.track.my.shot.data.test.account.info.TestCreateAccountFirebaseRealtimeDatabaseResult
+import com.nicholas.rutherford.track.my.shot.data.test.account.info.realtime.TestCreateAccountFirebaseRealtimeDatabaseResult
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic

--- a/firebase/read/build.gradle.kts
+++ b/firebase/read/build.gradle.kts
@@ -75,4 +75,6 @@ dependencies {
     testImplementation(Dependencies.Mockk.core)
 
     testRuntimeOnly(Dependencies.Junit.Jupiter.engine)
+
+    testImplementation(project(path = ":data-test:account-info"))
 }

--- a/firebase/read/build.gradle.kts
+++ b/firebase/read/build.gradle.kts
@@ -60,7 +60,10 @@ android {
 }
 
 dependencies {
+    api(project(path = ":data:account-info"))
+
     implementation(Dependencies.Firebase.authKtx)
+    implementation(Dependencies.Firebase.databaseKtx)
     implementation(Dependencies.Firebase.bom)
 
     testImplementation(Dependencies.Coroutine.test)

--- a/firebase/read/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/read/ReadFirebaseUserInfo.kt
+++ b/firebase/read/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/read/ReadFirebaseUserInfo.kt
@@ -1,8 +1,11 @@
 package com.nicholas.rutherford.track.my.shot.firebase.read
 
+import com.nicholas.rutherford.track.my.shot.account.info.realtime.AccountInfoRealtimeResponse
 import kotlinx.coroutines.flow.Flow
 
 interface ReadFirebaseUserInfo {
-    fun isEmailVerified(): Flow<Boolean>
-    fun isLoggedIn(): Flow<Boolean>
+    fun getLoggedInAccountEmail(): Flow<String?>
+    fun getAccountInfoFlowByEmail(email: String): Flow<AccountInfoRealtimeResponse?>
+    fun isEmailVerifiedFlow(): Flow<Boolean>
+    fun isLoggedInFlow(): Flow<Boolean>
 }

--- a/firebase/read/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/read/ReadFirebaseUserInfoImpl.kt
+++ b/firebase/read/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/read/ReadFirebaseUserInfoImpl.kt
@@ -1,13 +1,68 @@
 package com.nicholas.rutherford.track.my.shot.firebase.read
 
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.database.DataSnapshot
+import com.google.firebase.database.DatabaseError
+import com.google.firebase.database.FirebaseDatabase
+import com.google.firebase.database.ValueEventListener
+import com.nicholas.rutherford.track.my.shot.account.info.realtime.AccountInfoRealtimeResponse
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
-class ReadFirebaseUserInfoImpl(private val firebaseAuth: FirebaseAuth) : ReadFirebaseUserInfo {
+const val ACCOUNT_INFO = "accountInfo"
+const val EMAIL = "email"
+const val USERS = "users"
 
-    override fun isEmailVerified(): Flow<Boolean> {
+class ReadFirebaseUserInfoImpl(
+    private val firebaseAuth: FirebaseAuth,
+    private val firebaseDatabase: FirebaseDatabase
+) : ReadFirebaseUserInfo {
+
+    override fun getLoggedInAccountEmail(): Flow<String?> {
+        return callbackFlow {
+            firebaseAuth.currentUser?.let { user ->
+                trySend(element = user.email)
+            } ?: run {
+                trySend(element = null)
+            }
+            awaitClose()
+        }
+    }
+
+    override fun getAccountInfoFlowByEmail(email: String): Flow<AccountInfoRealtimeResponse?> {
+        return callbackFlow {
+            var accountInfoRealTimeResponse: AccountInfoRealtimeResponse? = null
+
+            firebaseDatabase.getReference(USERS)
+                .child(ACCOUNT_INFO)
+                .orderByChild(EMAIL)
+                .equalTo(email)
+                .addListenerForSingleValueEvent(object : ValueEventListener {
+                    override fun onDataChange(snapshot: DataSnapshot) {
+                        if (snapshot.exists()) {
+                            if (snapshot.children.count() == 1) {
+                                snapshot.children.map { child ->
+                                    accountInfoRealTimeResponse = child.getValue(AccountInfoRealtimeResponse::class.java)
+                                }
+                                trySend(element = accountInfoRealTimeResponse)
+                            } else {
+                                trySend(element = null)
+                            }
+                        } else {
+                            trySend(element = null)
+                        }
+                    }
+
+                    override fun onCancelled(error: DatabaseError) {
+                        trySend(element = null)
+                    }
+                })
+            awaitClose()
+        }
+    }
+
+    override fun isEmailVerifiedFlow(): Flow<Boolean> {
         return callbackFlow {
             firebaseAuth.currentUser?.let { firebaseUser ->
                 firebaseUser.reload().addOnCompleteListener { task ->
@@ -24,7 +79,7 @@ class ReadFirebaseUserInfoImpl(private val firebaseAuth: FirebaseAuth) : ReadFir
         }
     }
 
-    override fun isLoggedIn(): Flow<Boolean> {
+    override fun isLoggedInFlow(): Flow<Boolean> {
         return callbackFlow {
             trySend(element = firebaseAuth.currentUser != null)
             awaitClose()


### PR DESCRIPTION
### Trello
https://trello.com/c/vJmFwKIu/81-introduce-a-getallusersaccountinfobyid-realtime-database-method

### Issues
- We need a method to get account info in realtime database by a unique `email` identifier. This will look to see if the email is equal to the mapping reference and if so; will return back an account info response with require data. 
- We need a method to get the logged in `email` and returns tha data back via the flow. 

### Proposed Changes
- Add in functions
- Add in tests 
- Clean up some existing methods names

### TO-DO
- Add in a function that returns back a list of all account infos stored in the realtime firebase database. 

### Additional Info
- N/A 