### PR TITLE
nick: Authentication should have a spot on the UI where it checks to see if the account has been verified

### DIFF
--- a/base-resources/src/main/java/com/nicholas/rutherford/track/my/shot/feature/splash/StringsIds.kt
+++ b/base-resources/src/main/java/com/nicholas/rutherford/track/my/shot/feature/splash/StringsIds.kt
@@ -3,10 +3,13 @@ package com.nicholas.rutherford.track.my.shot.feature.splash
 import com.nicholas.rutherford.track.my.shot.base.resources.R
 
 object StringsIds {
+    val accountHasNotBeenVerified = R.string.account_has_not_been_verified
     val allFieldsAreRequired = R.string.all_fields_are_required
     val areYouSureYouWantLeaveTrackMyShot = R.string.are_you_sure_you_want_to_leave_track_my_shot
+    val checkIfAccountHaBeenVerified = R.string.check_if_account_has_been_verified
     val clickMeToCreateAccount = R.string.click_me_to_create_account
     val createAccount = R.string.create_account
+    val currentAccountHasNotBeenVerifiedPleaseOpenEmailToVerifyAccount = R.string.current_account_has_not_been_verified_please_open_email_to_verify_account
     val deviceIsCurrentlyNotConnectedToInternetDesc = R.string.device_is_currently_not_connected_to_internet_desc
     val emailHasBeenSentToRestPasswordPleaseFollowDirectionsToResetPassword = R.string.email_has_been_sent_to_reset_password_please_follow_directions_to_reset_password
     val emailHasBeenSentToVerifyAccountPleaseOpenEmailSentEmailToVerifyAccount = R.string.email_has_been_sent_to_verify_account_please_open_sent_email_to_verify_account

--- a/base-resources/src/main/res/values/strings.xml
+++ b/base-resources/src/main/res/values/strings.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="account_has_not_been_verified">Account Has Not Been Verified</string>
     <string name="all_fields_are_required">All Fields Are Required</string>
     <string name="are_you_sure_you_want_to_leave_track_my_shot">Are you sure you want to leave Track My Shot?</string>
+    <string name="check_if_account_has_been_verified">Check if account has been verified</string>
     <string name="click_me_to_create_account">Click me to create account</string>
     <string name="create_account">Create Account</string>
+    <string name="current_account_has_not_been_verified_please_open_email_to_verify_account">Current account has not been verified please open email to verify account.</string>
     <string name="device_is_currently_not_connected_to_internet_desc">Device is currently not connected to internet. Please connect device to internet to complete action.</string>
     <string name="forgot_password">Forgot Password</string>
     <string name="email_has_been_sent_to_reset_password_please_follow_directions_to_reset_password">Email has been sent to reset password. Please follow directions to reset password.</string>

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/authentication/AuthenticationScreen.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/authentication/AuthenticationScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
@@ -25,8 +26,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.Lifecycle
 import com.nicholas.rutherford.track.my.shot.compose.components.Content
 import com.nicholas.rutherford.track.my.shot.data.shared.appbar.AppBar
@@ -99,6 +102,18 @@ fun AuthenticationScreenContent(
             modifier = Modifier.padding(Padding.four),
             style = TextStyles.small,
             textAlign = TextAlign.Center,
+        )
+
+        Spacer(modifier = Modifier.height(Padding.four))
+
+        ClickableText(
+            text = AnnotatedString(stringResource(id = StringsIds.checkIfAccountHaBeenVerified)),
+            onClick = {
+                coroutineScope.launch {
+                    viewModel.onCheckIfAccountHaBeenVerifiedClicked()
+                }
+            },
+            style = TextStyles.hyperLink.copy(fontSize = 16.sp, color = Color.Blue)
         )
 
         Spacer(modifier = Modifier.height(Padding.eight))

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/authentication/AuthenticationViewModel.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/authentication/AuthenticationViewModel.kt
@@ -38,6 +38,8 @@ class AuthenticationViewModel(
         }
     }
 
+    internal suspend fun onCheckIfAccountHaBeenVerifiedClicked() = collectIfUserIsVerifiedAndAttemptToCreateAccount(shouldShowAccountIsNotVerifiedAlert = true)
+
     internal fun onNavigateClose() {
         navigation.alert(
             alert = Alert(
@@ -58,11 +60,9 @@ class AuthenticationViewModel(
 
     internal fun onAlertConfirmButtonClicked() = navigation.finish()
 
-    internal suspend fun onResume() {
-        collectIfUserIsVerifiedAndAttemptToCreateAccount()
-    }
+    internal suspend fun onResume() = collectIfUserIsVerifiedAndAttemptToCreateAccount(shouldShowAccountIsNotVerifiedAlert = false)
 
-    private suspend fun collectIfUserIsVerifiedAndAttemptToCreateAccount() {
+    private suspend fun collectIfUserIsVerifiedAndAttemptToCreateAccount(shouldShowAccountIsNotVerifiedAlert: Boolean) {
         readFirebaseUserInfo.isEmailVerifiedFlow().collectLatest { isVerified ->
             if (isVerified) {
                 safeLet(username, email) { usernameArgument, emailArgument ->
@@ -80,6 +80,10 @@ class AuthenticationViewModel(
                             navigation.alert(alert = errorCreatingAccountAlert())
                         }
                     }
+                }
+            } else {
+                if (shouldShowAccountIsNotVerifiedAlert) {
+                    navigation.alert(alert = errorVerifyingAccount())
                 }
             }
         }
@@ -105,6 +109,18 @@ class AuthenticationViewModel(
                 buttonText = application.getString(StringsIds.gotIt)
             ),
             description = application.getString(StringsIds.thereWasAErrorCreatingYourAccountPleaseTryAgain)
+        )
+    }
+
+    internal fun errorVerifyingAccount(): Alert {
+        return Alert(
+            onDismissClicked = {},
+            title = application.getString(StringsIds.accountHasNotBeenVerified),
+            dismissButton = AlertConfirmAndDismissButton(
+                onButtonClicked = {},
+                buttonText = application.getString(StringsIds.gotIt)
+            ),
+            description = application.getString(StringsIds.currentAccountHasNotBeenVerifiedPleaseOpenEmailToVerifyAccount)
         )
     }
 


### PR DESCRIPTION
### Trello
https://trello.com/c/09KW6dzx/102-authentication-should-listen-to-whenever-a-user-go-aheads-and-confirms-there-account

### Issues
- In the authentication flow; we don’t have a user indication to have the user check if the user has been authenticated yet. It is very possible; for a user to authenticate via their email or through another secondary phone.

### Proposed Changes
- Add some CTA that calls the method to check if the account has been verified or not. If it has not been; show an alert to the user.

### TO-DO
- N/A 
