### PR TITLE
nick: Make a username unique when creating a account

### DIFF
--- a/base-resources/src/main/java/com/nicholas/rutherford/track/my/shot/feature/splash/StringsIds.kt
+++ b/base-resources/src/main/java/com/nicholas/rutherford/track/my/shot/feature/splash/StringsIds.kt
@@ -54,6 +54,7 @@ object StringsIds {
     val unableToSendEmailVerification = R.string.unable_to_send_email_verification
     val userName = R.string.username
     val usernameInUse = R.string.username_in_use
+    val usernameIsNotInCorrectFormatPleaseEnterUsernameInCorrectFormat = R.string.username_is_not_in_correct_format_please_enter_username_in_correct_format
     val usernameIsRequiredPleaseEnterAUsernameToCreateAAccount = R.string.username_is_required_please_enter_a_username_to_create_a_account
     val verifyAccount = R.string.verify_account
     val weWereAbleToSendEmailVerificationPleaseCheckYourEmailToVerifyAccount = R.string.we_were_able_to_send_email_verification_please_check_your_email_to_verify_account

--- a/base-resources/src/main/res/values/strings.xml
+++ b/base-resources/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="try_again">Try Again</string>
     <string name="username">Username</string>
     <string name="username_in_use">Username in use</string>
+    <string name="username_is_not_in_correct_format_please_enter_username_in_correct_format">Username is not in correct format. Please enter username in correct format</string>
     <string name="unable_to_create_account">Unable to create account</string>
     <string name="unable_to_login_to_account">Unable to login to account</string>
     <string name="unable_to_reset_password">Unable to reset password</string>

--- a/compose-components/src/main/java/com/nicholas/rutherford/track/my/shot/compose/components/DialogWithTextField.kt
+++ b/compose-components/src/main/java/com/nicholas/rutherford/track/my/shot/compose/components/DialogWithTextField.kt
@@ -1,16 +1,7 @@
 package com.nicholas.rutherford.track.my.shot.compose.components
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material.OutlinedTextField
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -20,6 +11,18 @@ import com.nicholas.rutherford.track.my.shot.data.shared.alert.AlertConfirmAndDi
 import com.nicholas.rutherford.track.my.shot.helper.ui.Padding
 import com.nicholas.rutherford.track.my.shot.helper.ui.TextStyles
 
+/**
+ * Default [Dialog] with a given [TextField] inside with optional text and buttons. Used in [Content]
+ *
+ * @param onDismissClicked triggers whenever the user attempts to dismiss the [Dialog]
+ * @param title value of [Text] that sets the title displayed inside of the [Dialog]
+ * @param description value of [Text] that sets the description displayed inside of the [Dialog]
+ * @param textFieldValue value of the [OutlinedTextField] that displays inside of the [Dialog]
+ * @param textFieldLabelValue label of the [OutlinedTextField] that displays inside of the [Dialog]
+ * @param onValueChange triggers when the value is changed from the [OutlinedTextField]
+ * @param confirmButton optional param that by default is set to null. If its set to true, will set [DialogWithTextField] confirmButton properties
+ * @param dismissButton optional param that by default is set to null. If its set to true, will set [DialogWithTextField] dismissButton properties
+ */
 @Composable
 fun DialogWithTextField(
     onDismissClicked: () -> Unit,

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/createaccount/CreateAccountViewModel.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/createaccount/CreateAccountViewModel.kt
@@ -25,7 +25,7 @@ const val EMAIL_PATTERN = "^\\w+@[a-zA-Z_]+?\\.[a-zA-Z]{2,3}\$"
 const val PASSWORD_PATTERN = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@\$!%*?&])[A-Za-z\\d@\$!%*?&]{8,}\$"
 
 // 8 to 30 characters, only contain alphanumeric characters and underscores, first character must be alphabetic character
-const val USERNAME_PATTERN = "^[A-Za-z]\\w{7,29}\$"
+const val USERNAME_PATTERN = "^(?=[a-zA-Z\\d._]{8,20}\$)(?!.*[_.]{2})[^_.].*[^_.]\$"
 
 class CreateAccountViewModel(
     private val navigation: CreateAccountNavigation,

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/createaccount/CreateAccountViewModel.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/my/shot/feature/create/account/createaccount/CreateAccountViewModel.kt
@@ -24,6 +24,9 @@ const val EMAIL_PATTERN = "^\\w+@[a-zA-Z_]+?\\.[a-zA-Z]{2,3}\$"
 // Minimum eight characters, at least one uppercase letter, one lowercase letter, one number and one special character
 const val PASSWORD_PATTERN = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@\$!%*?&])[A-Za-z\\d@\$!%*?&]{8,}\$"
 
+// 8 to 30 characters, only contain alphanumeric characters and underscores, first character must be alphabetic character
+const val USERNAME_PATTERN = "^[A-Za-z]\\w{7,29}\$"
+
 class CreateAccountViewModel(
     private val navigation: CreateAccountNavigation,
     private val application: Application,
@@ -33,6 +36,7 @@ class CreateAccountViewModel(
 ) : ViewModel() {
 
     internal var isUsernameEmptyOrNull: Boolean = false
+    internal var isUsernameInNotCorrectFormat: Boolean = false
     internal var isEmailEmptyOrNull: Boolean = false
     internal var isEmailInNotCorrectFormat: Boolean = false
     internal var isPasswordEmptyOrNull: Boolean = false
@@ -60,14 +64,19 @@ class CreateAccountViewModel(
     fun onBackButtonClicked() = navigation.pop()
 
     fun onCreateAccountButtonClicked() {
-        navigation.enableProgress(progress = Progress(onDismissClicked = {}))
         val createAccountState = createAccountMutableStateFlow.value
 
+        navigation.enableProgress(progress = Progress(onDismissClicked = {}))
+
         setIsUsernameEmptyOrNull(username = createAccountState.username)
+        setIsUsernameInNotCorrectFormat(username = createAccountState.username)
+
         setIsEmailEmptyOrNull(email = createAccountState.email)
         setIsEmailInNotCorrectFormat(email = createAccountState.email)
+
         setIsPasswordEmptyOrNull(password = createAccountState.password)
         setIsPasswordNotInCorrectFormat(password = createAccountState.password)
+
         setIsTwoOrMoreFieldsEmptyOrNull()
 
         viewModelScope.launch {
@@ -91,6 +100,14 @@ class CreateAccountViewModel(
             isUsernameEmptyOrNull = value.isEmpty()
         } ?: run {
             isUsernameEmptyOrNull = true
+        }
+    }
+
+    internal fun setIsUsernameInNotCorrectFormat(username: String?) {
+        username?.let { value ->
+            isUsernameInNotCorrectFormat = !USERNAME_PATTERN.toRegex().matches(value)
+        } ?: run {
+            isUsernameInNotCorrectFormat = true
         }
     }
 
@@ -157,6 +174,11 @@ class CreateAccountViewModel(
             return defaultAlert.copy(
                 title = application.getString(StringsIds.emptyField),
                 description = application.getString(StringsIds.usernameIsRequiredPleaseEnterAUsernameToCreateAAccount)
+            )
+        } else if (isUsernameInNotCorrectFormat) {
+            return defaultAlert.copy(
+                title = application.getString(StringsIds.emptyField),
+                description = application.getString(StringsIds.usernameIsNotInCorrectFormatPleaseEnterUsernameInCorrectFormat)
             )
         } else if (isEmailEmptyOrNull) {
             return defaultAlert.copy(

--- a/feature/create-account/src/test/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountViewModelTest.kt
+++ b/feature/create-account/src/test/java/com/nicholas/rutherford/track/my/shot/feature/create/account/CreateAccountViewModelTest.kt
@@ -3,11 +3,7 @@ package com.nicholas.rutherford.track.my.shot.feature.create.account
 import android.app.Application
 import com.nicholas.rutherford.track.my.shot.data.test.account.info.TestAuthenticateUserViaEmailFirebaseResponse
 import com.nicholas.rutherford.track.my.shot.data.test.account.info.TestCreateAccountFirebaseAuthResponse
-import com.nicholas.rutherford.track.my.shot.feature.create.account.createaccount.CreateAccountNavigation
-import com.nicholas.rutherford.track.my.shot.feature.create.account.createaccount.CreateAccountState
-import com.nicholas.rutherford.track.my.shot.feature.create.account.createaccount.CreateAccountViewModel
-import com.nicholas.rutherford.track.my.shot.feature.create.account.createaccount.EMAIL_PATTERN
-import com.nicholas.rutherford.track.my.shot.feature.create.account.createaccount.PASSWORD_PATTERN
+import com.nicholas.rutherford.track.my.shot.feature.create.account.createaccount.*
 import com.nicholas.rutherford.track.my.shot.feature.splash.StringsIds
 import com.nicholas.rutherford.track.my.shot.firebase.create.CreateFirebaseUserInfo
 import com.nicholas.rutherford.track.my.shot.firebase.util.authentication.AuthenticationFirebase
@@ -72,6 +68,7 @@ class CreateAccountViewModelTest {
     fun constants() {
         Assertions.assertEquals(EMAIL_PATTERN, "^\\w+@[a-zA-Z_]+?\\.[a-zA-Z]{2,3}\$")
         Assertions.assertEquals(PASSWORD_PATTERN, "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@\$!%*?&])[A-Za-z\\d@\$!%*?&]{8,}\$")
+        Assertions.assertEquals(USERNAME_PATTERN, "^[A-Za-z]\\w{7,29}\$")
     }
 
     @Test


### PR DESCRIPTION
### Trello
https://trello.com/c/mXR681oZ/107-make-a-username-unique-when-creating-a-account

### Issues
- When we are creating an account we require a custom password as well as custom email. We do this by using Regex matching so that way we don’t let custom emails or passwords through the creation process. We already ensure that a user cannot create an account with a already duplicate username we should ensure that a user; may never create an account with a non unique username.

### Proposed Changes
- Apply the same logic for a custom username using regex so that way we have the same logic for password as well as email
- Update unit tests 

### TO-DO
- N/A 