### PR TITLE
nick: Update and add login tests to `LoginScreen`

### DIFF
--- a/feature/login/src/androidTest/java/com/nicholas/rutherford/track/my/shot/feature/login/LoginScreenTest.kt
+++ b/feature/login/src/androidTest/java/com/nicholas/rutherford/track/my/shot/feature/login/LoginScreenTest.kt
@@ -3,6 +3,7 @@ package com.nicholas.rutherford.track.my.shot.feature.login
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.nicholas.rutherford.track.my.shot.feature.splash.DrawablesIds
+import com.nicholas.rutherford.track.myshot.compose.content.test.rule.verifyTagIsNotDisplayed
 import com.nicholas.rutherford.track.myshot.compose.content.test.rule.verifyTagWithImageResIsDisplayed
 import com.nicholas.rutherford.track.myshot.compose.content.test.rule.verifyTagWithTextIsDisplayed
 import org.junit.Rule
@@ -43,7 +44,35 @@ class LoginScreenTest {
         composeTestRule.verifyTagWithTextIsDisplayed(text = "Email", testTag = LoginTags.EMAIL_TEXT_FIELD)
         composeTestRule.verifyTagWithTextIsDisplayed(text = "emailtest@yahoo.com", testTag = LoginTags.EMAIL_TEXT_FIELD)
         composeTestRule.verifyTagWithTextIsDisplayed(text = "Login", testTag = LoginTags.LOGIN_BUTTON)
+        composeTestRule.verifyTagWithTextIsDisplayed(text = "Forgot Password", testTag = LoginTags.FORGOT_PASSWORD_TEXT)
+        composeTestRule.verifyTagWithTextIsDisplayed(text = "Click me to create account", testTag = LoginTags.CLICK_ME_TO_CREATE_ACCOUNT_TEXT)
+    }
 
-        // verify rest of the elements here for testing
+    @Test
+    fun verifyContentwithValidStateWithLauncherDrawableIdSetToNull() {
+        composeTestRule.setContent {
+            val coroutineScope = rememberCoroutineScope()
+
+            LoginScreen(
+                loginScreenParams = LoginScreenParams(
+                    state = validLoginState.copy(launcherDrawableId = null),
+                    onEmailValueChanged = { },
+                    onPasswordValueChanged = { },
+                    onLoginButtonClicked = {},
+                    onForgotPasswordClicked = { },
+                    onCreateAccountClicked = { },
+                    coroutineScope = coroutineScope
+                )
+            )
+        }
+
+        composeTestRule.verifyTagIsNotDisplayed(testTag = LoginTags.LOGIN_APP_IMAGE)
+        composeTestRule.verifyTagWithTextIsDisplayed(text = "Proceed With Your Account", testTag = LoginTags.PROCEED_WITH_YOUR_ACCOUNT_TEXT)
+        composeTestRule.verifyTagWithTextIsDisplayed(text = "Login", testTag = LoginTags.LOGIN_TEXT)
+        composeTestRule.verifyTagWithTextIsDisplayed(text = "Email", testTag = LoginTags.EMAIL_TEXT_FIELD)
+        composeTestRule.verifyTagWithTextIsDisplayed(text = "emailtest@yahoo.com", testTag = LoginTags.EMAIL_TEXT_FIELD)
+        composeTestRule.verifyTagWithTextIsDisplayed(text = "Login", testTag = LoginTags.LOGIN_BUTTON)
+        composeTestRule.verifyTagWithTextIsDisplayed(text = "Forgot Password", testTag = LoginTags.FORGOT_PASSWORD_TEXT)
+        composeTestRule.verifyTagWithTextIsDisplayed(text = "Click me to create account", testTag = LoginTags.CLICK_ME_TO_CREATE_ACCOUNT_TEXT)
     }
 }

--- a/feature/login/src/main/java/com/nicholas/rutherford/track/my/shot/feature/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/nicholas/rutherford/track/my/shot/feature/login/LoginScreen.kt
@@ -123,8 +123,7 @@ fun LoginScreenContent(loginScreenParams: LoginScreenParams) {
                     Text(
                         text = stringResource(id = StringsIds.login),
                         style = TextStyles.small,
-                        color = Color.White,
-                        modifier = Modifier.testTag(tag = LoginTags.LOGIN_BUTTON_TEXT)
+                        color = Color.White
                     )
                 }
             )

--- a/feature/login/src/main/java/com/nicholas/rutherford/track/my/shot/feature/login/LoginTags.kt
+++ b/feature/login/src/main/java/com/nicholas/rutherford/track/my/shot/feature/login/LoginTags.kt
@@ -7,7 +7,6 @@ object LoginTags {
     const val EMAIL_TEXT_FIELD = "email_text_field"
     const val PASSWORD_TEXT_FIELD = "password_text_field"
     const val LOGIN_BUTTON = "login_button"
-    const val LOGIN_BUTTON_TEXT = "login_button_text"
     const val FORGOT_PASSWORD_TEXT = "forgot_password_text"
     const val CLICK_ME_TO_CREATE_ACCOUNT_TEXT = "click_me_to_create_account_text"
 }

--- a/feature/login/src/test/java/com/nicholas/rutherford/track/my/shot/feature/login/LoginTagsTest.kt
+++ b/feature/login/src/test/java/com/nicholas/rutherford/track/my/shot/feature/login/LoginTagsTest.kt
@@ -40,11 +40,6 @@ class LoginTagsTest {
         }
 
         @Test
-        fun `login button text`() {
-            Assertions.assertEquals(LoginTags.LOGIN_BUTTON_TEXT, "login_button_text")
-        }
-
-        @Test
         fun `forgot password text`() {
             Assertions.assertEquals(LoginTags.FORGOT_PASSWORD_TEXT, "forgot_password_text")
         }

--- a/helper/compose-content-test-rule/src/main/java/com/nicholas/rutherford/track/myshot/compose/content/test/rule/ComposeContentTestRuleExtension.kt
+++ b/helper/compose-content-test-rule/src/main/java/com/nicholas/rutherford/track/myshot/compose/content/test/rule/ComposeContentTestRuleExtension.kt
@@ -20,7 +20,7 @@ fun ComposeContentTestRule.verifyTagWithImageResIsDisplayed(id: Int, testTag: St
 }
 
 fun ComposeContentTestRule.verifyTagIsNotDisplayed(testTag: String) {
-    this.onNodeWithTag(testTag = testTag).assertIsNotDisplayed()
+    this.onNodeWithTag(testTag = testTag).assertDoesNotExist()
 }
 
 fun ComposeContentTestRule.verifyTagWithTextIsDisplayed(text: String, testTag: String) {


### PR DESCRIPTION
### Trello
- N/A 

### Issues
- We want to have a new standard that every single time we create a Compose screen we had UI tests. This should test logic going on in the Compose screen. We currently don't have UI tests setup for `LoginScreen`.

### Proposed Changes
- Setup tand update tests for `LoginScreen`. 

### TO-DO
- Add more tests through the project. 

### Additional Info
- N/A 

### Screenshots / Videos 
- N/A 