### PR TITLE
nick: Create firebase method to create a given player

### DIFF
--- a/data-test/firebase/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/realtime/TestPlayerInfoRealtimeResponse.kt
+++ b/data-test/firebase/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/realtime/TestPlayerInfoRealtimeResponse.kt
@@ -1,0 +1,18 @@
+package com.nicholas.rutherford.track.my.shot.firebase.realtime
+
+class TestPlayerInfoRealtimeResponse {
+
+    fun create(): PlayerInfoRealtimeResponse {
+        return PlayerInfoRealtimeResponse(
+            firstName = FIRST_NAME,
+            lastName = LAST_NAME,
+            positionValue = POSITION_VALUE,
+            imageUrl = IMAGE_URL
+        )
+    }
+}
+
+const val FIRST_NAME = "firstName"
+const val LAST_NAME = "lastName"
+const val POSITION_VALUE = 2
+const val IMAGE_URL = "imageUrl"

--- a/data/firebase/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/realtime/PlayerInfoRealtimeResponse.kt
+++ b/data/firebase/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/realtime/PlayerInfoRealtimeResponse.kt
@@ -1,0 +1,8 @@
+package com.nicholas.rutherford.track.my.shot.firebase.realtime
+
+data class PlayerInfoRealtimeResponse(
+    val firstName: String = "",
+    val lastName: String = "",
+    val positionValue: Int = 0,
+    val imageUrl: String = ""
+)

--- a/firebase/create/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfo.kt
+++ b/firebase/create/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfo.kt
@@ -1,9 +1,11 @@
 package com.nicholas.rutherford.track.my.shot.firebase.create
 
 import com.nicholas.rutherford.track.my.shot.firebase.CreateAccountFirebaseAuthResponse
+import com.nicholas.rutherford.track.my.shot.firebase.realtime.PlayerInfoRealtimeResponse
 import kotlinx.coroutines.flow.Flow
 
 interface CreateFirebaseUserInfo {
     fun attemptToCreateAccountFirebaseAuthResponseFlow(email: String, password: String): Flow<CreateAccountFirebaseAuthResponse>
     fun attemptToCreateAccountFirebaseRealTimeDatabaseResponseFlow(userName: String, email: String): Flow<Pair<Boolean, String?>>
+    fun attemptToCreatePlayerFirebaseRealtimeDatabaseResponseFlow(key: String, playerInfoRealtimeResponse: PlayerInfoRealtimeResponse): Flow<Boolean>
 }

--- a/firebase/create/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfoImpl.kt
+++ b/firebase/create/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/create/CreateFirebaseUserInfoImpl.kt
@@ -4,6 +4,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.FirebaseDatabase
 import com.nicholas.rutherford.track.my.shot.firebase.CreateAccountFirebaseAuthResponse
 import com.nicholas.rutherford.track.my.shot.firebase.realtime.CreateAccountFirebaseRealtimeDatabaseResult
+import com.nicholas.rutherford.track.my.shot.firebase.realtime.PlayerInfoRealtimeResponse
 import com.nicholas.rutherford.track.my.shot.helper.constants.Constants
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -70,6 +71,33 @@ class CreateFirebaseUserInfoImpl(
                         Timber.w(message = "Warning(attemptToCreateAccountFirebaseRealTimeDatabaseResponseFlow) -> Creating account failed to create in Firebase Realtime Database")
                         trySend(Pair(first = false, second = null))
                     }
+                }
+            awaitClose()
+        }
+    }
+
+    override fun attemptToCreatePlayerFirebaseRealtimeDatabaseResponseFlow(
+        key: String,
+        playerInfoRealtimeResponse: PlayerInfoRealtimeResponse
+    ): Flow<Boolean> {
+        return callbackFlow {
+            val userAccountInfoDatabaseReference =
+                userReference
+                    .child(Constants.ACCOUNT_INFO)
+                    .child(key)
+                    .child(Constants.PLAYERS)
+
+            val newPlayerReference = userAccountInfoDatabaseReference.push()
+            val values = hashMapOf<String, Any>()
+
+            values[Constants.FIRST_NAME] = playerInfoRealtimeResponse.firstName
+            values[Constants.LAST_NAME] = playerInfoRealtimeResponse.lastName
+            values[Constants.POSITION_VALUE] = playerInfoRealtimeResponse.positionValue
+            values[Constants.IMAGE_URL] = playerInfoRealtimeResponse.imageUrl
+
+            newPlayerReference.setValue(values)
+                .addOnCompleteListener { task ->
+                    trySend(task.isSuccessful)
                 }
             awaitClose()
         }

--- a/helper/constants/src/main/java/com/nicholas/rutherford/track/my/shot/helper/constants/Constants.kt
+++ b/helper/constants/src/main/java/com/nicholas/rutherford/track/my/shot/helper/constants/Constants.kt
@@ -7,7 +7,12 @@ object Constants {
     const val CENTER = 4
     const val CONTENT_LAST_UPDATED_PATH = "contentLastUpdated"
     const val EMAIL = "email"
+    const val FIRST_NAME = "firstName"
+    const val IMAGE_URL = "imageUrl"
+    const val LAST_NAME = "lastName"
     const val LAST_UPDATED = "lastUpdated"
+    const val PLAYERS = "players"
+    const val POSITION_VALUE = "positionValue"
     const val USERS_PATH = "users"
     const val POINT_GUARD_VALUE = 0
     const val SHOOTING_GUARD_VALUE = 1


### PR DESCRIPTION
### Trello
- https://trello.com/c/MW0nJ9DF/131-create-firebase-method-to-create-a-given-player

### Issues
- We want to make an addition to our firebase realtime database to include the ability to create a player. The following will be data that will be uploaded up to the database that will include a table:


`data class PlayerInfoRealtimeResponse(val firstName: String = "",val lastName: String = "",val positionValue: Int = 0,val imageUrl: String = "")`

We will also need to ability to add more than player for a given user account, in order to support adding more than one player. The player itself should be sent up as a unique identify key, so that way we have the ability to retrieve a player by a key if necessary.

### Proposed Changes
- Ability to create a player within realtime database with correct request type. This should also be saved under a unique key, in order to upload multiple players to a given user account.

### TO-DO
- Room functions to create, read, and update a given player 
- Read function in firebase to fetch all players on an account for a user. 
- Possibly a firebase edit a player function? 

### Additional Info
- N/A 

### Screenshots / Videos 
- N/A 