### PR TITLE
nick: Firebase method to delete a given player and update fetch player list to include the player firebase key

### DIFF
--- a/app/src/main/java/com/nicholas/rutherford/track/my/shot/AppModule.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/my/shot/AppModule.kt
@@ -164,9 +164,7 @@ class AppModule {
         }
         viewModel {
             PlayersListViewModel(
-                get(),
-                get(),
-                get()
+                readFirebaseUserInfo = get()
             )
         }
         viewModel {

--- a/app/src/main/java/com/nicholas/rutherford/track/my/shot/AppModule.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/my/shot/AppModule.kt
@@ -33,6 +33,8 @@ import com.nicholas.rutherford.track.my.shot.firebase.core.create.CreateFirebase
 import com.nicholas.rutherford.track.my.shot.firebase.core.create.CreateFirebaseLastUpdatedImpl
 import com.nicholas.rutherford.track.my.shot.firebase.core.create.CreateFirebaseUserInfo
 import com.nicholas.rutherford.track.my.shot.firebase.core.create.CreateFirebaseUserInfoImpl
+import com.nicholas.rutherford.track.my.shot.firebase.core.delete.DeleteFirebaseUserInfo
+import com.nicholas.rutherford.track.my.shot.firebase.core.delete.DeleteFirebaseUserInfoImpl
 import com.nicholas.rutherford.track.my.shot.firebase.core.read.ReadFirebaseUserInfo
 import com.nicholas.rutherford.track.my.shot.firebase.core.read.ReadFirebaseUserInfoImpl
 import com.nicholas.rutherford.track.my.shot.firebase.util.authentication.AuthenticationFirebase
@@ -110,6 +112,9 @@ class AppModule {
         single<ReadFirebaseUserInfo> {
             ReadFirebaseUserInfoImpl(firebaseAuth = get(), firebaseDatabase = get())
         }
+        single<DeleteFirebaseUserInfo> {
+            DeleteFirebaseUserInfoImpl(firebaseDatabase = get())
+        }
         single<Network> {
             NetworkImpl()
         }
@@ -159,7 +164,8 @@ class AppModule {
         }
         viewModel {
             PlayersListViewModel(
-                readFirebaseUserInfo = get()
+                get(),
+                get()
             )
         }
         viewModel {

--- a/app/src/main/java/com/nicholas/rutherford/track/my/shot/AppModule.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/my/shot/AppModule.kt
@@ -165,6 +165,7 @@ class AppModule {
         viewModel {
             PlayersListViewModel(
                 get(),
+                get(),
                 get()
             )
         }

--- a/data-test/firebase/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/realtime/TestPlayerInfoRealtimeWithKeyResponse.kt
+++ b/data-test/firebase/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/realtime/TestPlayerInfoRealtimeWithKeyResponse.kt
@@ -1,0 +1,12 @@
+package com.nicholas.rutherford.track.my.shot.firebase.realtime
+
+const val PLAYER_FIREBASE_KEY = "-j0P5J2LcXmXF"
+class TestPlayerInfoRealtimeWithKeyResponse {
+
+    fun create(): PlayerInfoRealtimeWithKeyResponse {
+        return PlayerInfoRealtimeWithKeyResponse(
+            playerFirebaseKey = PLAYER_FIREBASE_KEY,
+            playerInfo = TestPlayerInfoRealtimeResponse().create()
+        )
+    }
+}

--- a/data/firebase/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/realtime/PlayerInfoRealtimeWithKeyResponse.kt
+++ b/data/firebase/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/realtime/PlayerInfoRealtimeWithKeyResponse.kt
@@ -1,0 +1,6 @@
+package com.nicholas.rutherford.track.my.shot.firebase.realtime
+
+data class PlayerInfoRealtimeWithKeyResponse(
+    val playerFirebaseKey: String,
+    val playerInfo: PlayerInfoRealtimeResponse
+)

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/my/shot/feature/players/PlayersListViewModel.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/my/shot/feature/players/PlayersListViewModel.kt
@@ -1,14 +1,19 @@
 package com.nicholas.rutherford.track.my.shot.feature.players
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nicholas.rutherford.track.my.shot.data.room.repository.ActiveUserRepository
 import com.nicholas.rutherford.track.my.shot.data.room.response.Player
-import com.nicholas.rutherford.track.my.shot.firebase.core.read.ReadFirebaseUserInfo
+import com.nicholas.rutherford.track.my.shot.firebase.core.delete.DeleteFirebaseUserInfo
 import com.nicholas.rutherford.track.my.shot.firebase.realtime.PlayerInfoRealtimeResponse
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 class PlayersListViewModel(
-    private val readFirebaseUserInfo: ReadFirebaseUserInfo
+    private val activeUserRepository: ActiveUserRepository,
+    private val deleteFirebaseUserInfo: DeleteFirebaseUserInfo
 ) : ViewModel() {
 
     private val playerListMutableStateFlow = MutableStateFlow(
@@ -21,6 +26,23 @@ class PlayersListViewModel(
     var playerList: List<PlayerInfoRealtimeResponse> = emptyList()
 
     val playerListStateFlow = playerListMutableStateFlow.asStateFlow()
+
+    init {
+        println("get here adada121")
+        viewModelScope.launch {
+            val activeUser = activeUserRepository.fetchActiveUser()
+
+            activeUser?.firebaseAccountInfoKey?.let { key ->
+                deleteFirebaseUserInfo.deletePlayer(key, "-NgBYJxvXcIzW9fVlj5r").collectLatest { result ->
+                    if (result) {
+                        println("was able to get created")
+                    } else {
+                        println("was not able to get created")
+                    }
+                }
+            }
+        }
+    }
 
     fun validatePlayer(player: Player) {
         if (player.firstName.isNotEmpty() && player.lastName.isNotEmpty()) {

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/my/shot/feature/players/PlayersListViewModel.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/my/shot/feature/players/PlayersListViewModel.kt
@@ -4,7 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.nicholas.rutherford.track.my.shot.data.room.repository.ActiveUserRepository
 import com.nicholas.rutherford.track.my.shot.data.room.response.Player
-import com.nicholas.rutherford.track.my.shot.firebase.core.delete.DeleteFirebaseUserInfo
+import com.nicholas.rutherford.track.my.shot.firebase.core.create.CreateFirebaseUserInfo
+import com.nicholas.rutherford.track.my.shot.firebase.core.read.ReadFirebaseUserInfo
 import com.nicholas.rutherford.track.my.shot.firebase.realtime.PlayerInfoRealtimeResponse
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -13,7 +14,8 @@ import kotlinx.coroutines.launch
 
 class PlayersListViewModel(
     private val activeUserRepository: ActiveUserRepository,
-    private val deleteFirebaseUserInfo: DeleteFirebaseUserInfo
+    private val readFirebaseUserInfoImpl: ReadFirebaseUserInfo,
+    private val createFirebaseUserInfo: CreateFirebaseUserInfo
 ) : ViewModel() {
 
     private val playerListMutableStateFlow = MutableStateFlow(
@@ -33,11 +35,9 @@ class PlayersListViewModel(
             val activeUser = activeUserRepository.fetchActiveUser()
 
             activeUser?.firebaseAccountInfoKey?.let { key ->
-                deleteFirebaseUserInfo.deletePlayer(key, "-NgBYJxvXcIzW9fVlj5r").collectLatest { result ->
-                    if (result) {
-                        println("was able to get created")
-                    } else {
-                        println("was not able to get created")
+                readFirebaseUserInfoImpl.getPlayerInfoList(key).collectLatest { result ->
+                    result.forEach {
+                        println("here is the raw response $it")
                     }
                 }
             }

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/my/shot/feature/players/PlayersListViewModel.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/my/shot/feature/players/PlayersListViewModel.kt
@@ -1,21 +1,14 @@
 package com.nicholas.rutherford.track.my.shot.feature.players
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.nicholas.rutherford.track.my.shot.data.room.repository.ActiveUserRepository
 import com.nicholas.rutherford.track.my.shot.data.room.response.Player
-import com.nicholas.rutherford.track.my.shot.firebase.core.create.CreateFirebaseUserInfo
 import com.nicholas.rutherford.track.my.shot.firebase.core.read.ReadFirebaseUserInfo
 import com.nicholas.rutherford.track.my.shot.firebase.realtime.PlayerInfoRealtimeResponse
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
 
 class PlayersListViewModel(
-    private val activeUserRepository: ActiveUserRepository,
-    private val readFirebaseUserInfoImpl: ReadFirebaseUserInfo,
-    private val createFirebaseUserInfo: CreateFirebaseUserInfo
+    private val readFirebaseUserInfo: ReadFirebaseUserInfo
 ) : ViewModel() {
 
     private val playerListMutableStateFlow = MutableStateFlow(
@@ -28,21 +21,6 @@ class PlayersListViewModel(
     var playerList: List<PlayerInfoRealtimeResponse> = emptyList()
 
     val playerListStateFlow = playerListMutableStateFlow.asStateFlow()
-
-    init {
-        println("get here adada121")
-        viewModelScope.launch {
-            val activeUser = activeUserRepository.fetchActiveUser()
-
-            activeUser?.firebaseAccountInfoKey?.let { key ->
-                readFirebaseUserInfoImpl.getPlayerInfoList(key).collectLatest { result ->
-                    result.forEach {
-                        println("here is the raw response $it")
-                    }
-                }
-            }
-        }
-    }
 
     fun validatePlayer(player: Player) {
         if (player.firstName.isNotEmpty() && player.lastName.isNotEmpty()) {

--- a/firebase/core/build.gradle.kts
+++ b/firebase/core/build.gradle.kts
@@ -63,6 +63,7 @@ android {
 dependencies {
     api(project(":data:firebase"))
     api(project(path = ":helper:constants"))
+    api(project(path = ":helper:extensions"))
 
     implementation(Dependencies.Firebase.authKtx)
     implementation(Dependencies.Firebase.bom)

--- a/firebase/core/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/core/delete/DeleteFirebaseUserInfo.kt
+++ b/firebase/core/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/core/delete/DeleteFirebaseUserInfo.kt
@@ -1,0 +1,7 @@
+package com.nicholas.rutherford.track.my.shot.firebase.core.delete
+
+import kotlinx.coroutines.flow.Flow
+
+interface DeleteFirebaseUserInfo {
+    fun deletePlayer(accountKey: String, playerKey: String): Flow<Boolean>
+}

--- a/firebase/core/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/core/delete/DeleteFirebaseUserInfoImpl.kt
+++ b/firebase/core/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/core/delete/DeleteFirebaseUserInfoImpl.kt
@@ -1,0 +1,34 @@
+package com.nicholas.rutherford.track.my.shot.firebase.core.delete
+
+import com.google.firebase.database.FirebaseDatabase
+import com.nicholas.rutherford.track.my.shot.helper.constants.Constants
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import timber.log.Timber
+
+class DeleteFirebaseUserInfoImpl(private val firebaseDatabase: FirebaseDatabase) : DeleteFirebaseUserInfo {
+
+    override fun deletePlayer(
+        accountKey: String,
+        playerKey: String
+    ): Flow<Boolean> {
+        return callbackFlow {
+            firebaseDatabase.getReference(Constants.USERS)
+                .child(Constants.ACCOUNT_INFO)
+                .child(accountKey)
+                .child(Constants.PLAYERS)
+                .child(playerKey)
+                .removeValue()
+                .addOnCompleteListener { task ->
+                    if (task.isSuccessful) {
+                        trySend(element = true)
+                    } else {
+                        Timber.w(message = "Warning(deletePlayer) -> Was not able to delete current player from given account.")
+                        trySend(element = false)
+                    }
+                }
+            awaitClose()
+        }
+    }
+}

--- a/firebase/core/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/core/read/ReadFirebaseUserInfo.kt
+++ b/firebase/core/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/core/read/ReadFirebaseUserInfo.kt
@@ -1,7 +1,7 @@
 package com.nicholas.rutherford.track.my.shot.firebase.core.read
 
 import com.nicholas.rutherford.track.my.shot.firebase.realtime.AccountInfoRealtimeResponse
-import com.nicholas.rutherford.track.my.shot.firebase.realtime.PlayerInfoRealtimeResponse
+import com.nicholas.rutherford.track.my.shot.firebase.realtime.PlayerInfoRealtimeWithKeyResponse
 import kotlinx.coroutines.flow.Flow
 import java.util.Date
 
@@ -10,7 +10,7 @@ interface ReadFirebaseUserInfo {
     fun getAccountInfoFlowByEmail(email: String): Flow<AccountInfoRealtimeResponse?>
     fun getAccountInfoListFlow(): Flow<List<AccountInfoRealtimeResponse>?>
     fun getAccountInfoKeyFlowByEmail(email: String): Flow<String?>
-    fun getPlayerInfoList(accountKey: String): Flow<List<PlayerInfoRealtimeResponse>>
+    fun getPlayerInfoList(accountKey: String): Flow<List<PlayerInfoRealtimeWithKeyResponse>>
     fun getLastUpdatedDateFlow(): Flow<Date?>
     fun isEmailVerifiedFlow(): Flow<Boolean>
     fun isLoggedInFlow(): Flow<Boolean>

--- a/firebase/core/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/core/read/ReadFirebaseUserInfoImpl.kt
+++ b/firebase/core/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/core/read/ReadFirebaseUserInfoImpl.kt
@@ -186,8 +186,6 @@ class ReadFirebaseUserInfoImpl(
                                         playerInfoRealtimeWithKeyResponseArrayList.add(
                                             PlayerInfoRealtimeWithKeyResponse(playerFirebaseKey = playerFirebaseKey, playerInfo = playerInfo)
                                         )
-                                    } ?: run {
-                                        // one of the values were null when we looped thorugh
                                     }
                                 }
                             }

--- a/firebase/core/src/test/java/com/nicholas/rutherford/track/my/shot/firebase/core/delete/DeleteFirebaseUserInfoImplTest.kt
+++ b/firebase/core/src/test/java/com/nicholas/rutherford/track/my/shot/firebase/core/delete/DeleteFirebaseUserInfoImplTest.kt
@@ -1,4 +1,99 @@
 package com.nicholas.rutherford.track.my.shot.firebase.core.delete
 
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.database.FirebaseDatabase
+import com.nicholas.rutherford.track.my.shot.helper.constants.Constants
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
 class DeleteFirebaseUserInfoImplTest {
+
+    private lateinit var deleteFirebaseUserInfoImpl: DeleteFirebaseUserInfoImpl
+
+    private val firebaseDatabase = mockk<FirebaseDatabase>(relaxed = true)
+
+    val firebaseAccountKey = "-kTE1212D"
+    val firebasePlayerKey = "-zRTW11129"
+
+    @BeforeEach
+    fun beforeEach() {
+        deleteFirebaseUserInfoImpl = DeleteFirebaseUserInfoImpl(firebaseDatabase = firebaseDatabase)
+    }
+
+    @Nested
+    inner class DeletePlayer {
+
+        @OptIn(ExperimentalCoroutinesApi::class)
+        @Test
+        fun `when add on complete listener is executed and returns isSuccessful returns true should set flow to true`() = runTest {
+            val mockTaskVoidResult = mockk<Task<Void>>()
+            val slot = slot<OnCompleteListener<Void>>()
+
+            mockkStatic(Tasks::class)
+
+            every { mockTaskVoidResult.isSuccessful } returns true
+
+            every {
+                firebaseDatabase.getReference(Constants.USERS)
+                    .child(Constants.ACCOUNT_INFO)
+                    .child(firebaseAccountKey)
+                    .child(Constants.PLAYERS)
+                    .child(firebasePlayerKey)
+                    .removeValue()
+                    .addOnCompleteListener(capture(slot))
+            } answers {
+                slot.captured.onComplete(mockTaskVoidResult)
+                mockTaskVoidResult
+            }
+
+            val value = deleteFirebaseUserInfoImpl.deletePlayer(
+                accountKey = firebaseAccountKey,
+                playerKey = firebasePlayerKey
+            ).first()
+
+            Assertions.assertEquals(true, value)
+        }
+
+        @OptIn(ExperimentalCoroutinesApi::class)
+        @Test
+        fun `when add on complete listener is executed and returns isSuccessful returns back false should set flow to false`() = runTest {
+            val mockTaskVoidResult = mockk<Task<Void>>()
+            val slot = slot<OnCompleteListener<Void>>()
+
+            mockkStatic(Tasks::class)
+
+            every { mockTaskVoidResult.isSuccessful } returns false
+
+            every {
+                firebaseDatabase.getReference(Constants.USERS)
+                    .child(Constants.ACCOUNT_INFO)
+                    .child(firebaseAccountKey)
+                    .child(Constants.PLAYERS)
+                    .child(firebasePlayerKey)
+                    .removeValue()
+                    .addOnCompleteListener(capture(slot))
+            } answers {
+                slot.captured.onComplete(mockTaskVoidResult)
+                mockTaskVoidResult
+            }
+
+            val value = deleteFirebaseUserInfoImpl.deletePlayer(
+                accountKey = firebaseAccountKey,
+                playerKey = firebasePlayerKey
+            ).first()
+
+            Assertions.assertEquals(false, value)
+        }
+    }
 }

--- a/firebase/core/src/test/java/com/nicholas/rutherford/track/my/shot/firebase/core/delete/DeleteFirebaseUserInfoImplTest.kt
+++ b/firebase/core/src/test/java/com/nicholas/rutherford/track/my/shot/firebase/core/delete/DeleteFirebaseUserInfoImplTest.kt
@@ -1,0 +1,4 @@
+package com.nicholas.rutherford.track.my.shot.firebase.core.delete
+
+class DeleteFirebaseUserInfoImplTest {
+}

--- a/firebase/core/src/test/java/com/nicholas/rutherford/track/my/shot/firebase/core/read/ReadFirebaseUserInfoImplTest.kt
+++ b/firebase/core/src/test/java/com/nicholas/rutherford/track/my/shot/firebase/core/read/ReadFirebaseUserInfoImplTest.kt
@@ -539,16 +539,16 @@ class ReadFirebaseUserInfoImplTest {
 
             val playerInfoRealtimeWithKeyResponseList = listOf(
                 TestPlayerInfoRealtimeWithKeyResponse().create(),
-                TestPlayerInfoRealtimeWithKeyResponse().create().copy(playerInfo = TestPlayerInfoRealtimeResponse().create().copy(firstName = "firstName2"))
+                TestPlayerInfoRealtimeWithKeyResponse().create().copy(playerFirebaseKey = "-NgBwuq_5kti8ChLDuhc", playerInfo = TestPlayerInfoRealtimeResponse().create().copy(firstName = "firstName2"))
             )
 
             every { mockDataSnapshot.exists() } returns true
             every { mockDataSnapshot.childrenCount } returns playerInfoRealtimeWithKeyResponseList.size.toLong()
 
-            every { mockDataSnapshot.key } returns playerInfoRealtimeWithKeyResponseList[0].playerFirebaseKey
-            every { mockDataSnapshot.children } returns playerInfoRealtimeWithKeyResponseList.map { playerInfo ->
+            every { mockDataSnapshot.children } returns playerInfoRealtimeWithKeyResponseList.map { playerInfoRealtimeWithKey ->
                 val mockChildSnapshot = mockk<DataSnapshot>()
-                every { mockChildSnapshot.getValue(PlayerInfoRealtimeResponse::class.java) } returns playerInfo.playerInfo
+                every { mockChildSnapshot.key } returns playerInfoRealtimeWithKey.playerFirebaseKey
+                every { mockChildSnapshot.getValue(PlayerInfoRealtimeResponse::class.java) } returns playerInfoRealtimeWithKey.playerInfo
                 mockChildSnapshot
             }
 

--- a/firebase/core/src/test/java/com/nicholas/rutherford/track/my/shot/firebase/core/read/ReadFirebaseUserInfoImplTest.kt
+++ b/firebase/core/src/test/java/com/nicholas/rutherford/track/my/shot/firebase/core/read/ReadFirebaseUserInfoImplTest.kt
@@ -10,8 +10,10 @@ import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ValueEventListener
 import com.nicholas.rutherford.track.my.shot.firebase.realtime.AccountInfoRealtimeResponse
 import com.nicholas.rutherford.track.my.shot.firebase.realtime.PlayerInfoRealtimeResponse
+import com.nicholas.rutherford.track.my.shot.firebase.realtime.PlayerInfoRealtimeWithKeyResponse
 import com.nicholas.rutherford.track.my.shot.firebase.realtime.TestAccountInfoRealTimeResponse
 import com.nicholas.rutherford.track.my.shot.firebase.realtime.TestPlayerInfoRealtimeResponse
+import com.nicholas.rutherford.track.my.shot.firebase.realtime.TestPlayerInfoRealtimeWithKeyResponse
 import com.nicholas.rutherford.track.my.shot.helper.constants.Constants
 import io.mockk.every
 import io.mockk.mockk
@@ -461,7 +463,7 @@ class ReadFirebaseUserInfoImplTest {
 
     @Nested
     inner class GetPlayerInfoList {
-        private val playerInfoRealtimeResponseEmptyList: List<PlayerInfoRealtimeResponse> = emptyList()
+        private val playerInfoRealtimeWithKeyResponseEmptyList: List<PlayerInfoRealtimeWithKeyResponse> = emptyList()
 
         @OptIn(ExperimentalCoroutinesApi::class)
         @Test
@@ -479,7 +481,7 @@ class ReadFirebaseUserInfoImplTest {
                 slot.captured.onCancelled(mockDatabaseError)
             }
 
-            Assertions.assertEquals(playerInfoRealtimeResponseEmptyList, readFirebaseUserInfoImpl.getPlayerInfoList(accountKey = firebaseAccountKey).first())
+            Assertions.assertEquals(playerInfoRealtimeWithKeyResponseEmptyList, readFirebaseUserInfoImpl.getPlayerInfoList(accountKey = firebaseAccountKey).first())
         }
 
         @OptIn(ExperimentalCoroutinesApi::class)
@@ -502,7 +504,7 @@ class ReadFirebaseUserInfoImplTest {
                 slot.captured.onDataChange(mockDataSnapshot)
             }
 
-            Assertions.assertEquals(playerInfoRealtimeResponseEmptyList, readFirebaseUserInfoImpl.getPlayerInfoList(accountKey = firebaseAccountKey).first())
+            Assertions.assertEquals(playerInfoRealtimeWithKeyResponseEmptyList, readFirebaseUserInfoImpl.getPlayerInfoList(accountKey = firebaseAccountKey).first())
         }
 
         @OptIn(ExperimentalCoroutinesApi::class)
@@ -526,7 +528,7 @@ class ReadFirebaseUserInfoImplTest {
                 slot.captured.onDataChange(mockDataSnapshot)
             }
 
-            Assertions.assertEquals(playerInfoRealtimeResponseEmptyList, readFirebaseUserInfoImpl.getPlayerInfoList(accountKey = firebaseAccountKey).first())
+            Assertions.assertEquals(playerInfoRealtimeWithKeyResponseEmptyList, readFirebaseUserInfoImpl.getPlayerInfoList(accountKey = firebaseAccountKey).first())
         }
 
         @OptIn(ExperimentalCoroutinesApi::class)
@@ -535,17 +537,18 @@ class ReadFirebaseUserInfoImplTest {
             val mockDataSnapshot = mockk<DataSnapshot>()
             val slot = slot<ValueEventListener>()
 
-            val playerInfoRealtimeResponseList = listOf(
-                TestPlayerInfoRealtimeResponse().create(),
-                TestPlayerInfoRealtimeResponse().create().copy(firstName = "firstName2")
+            val playerInfoRealtimeWithKeyResponseList = listOf(
+                TestPlayerInfoRealtimeWithKeyResponse().create(),
+                TestPlayerInfoRealtimeWithKeyResponse().create().copy(playerInfo = TestPlayerInfoRealtimeResponse().create().copy(firstName = "firstName2"))
             )
 
             every { mockDataSnapshot.exists() } returns true
-            every { mockDataSnapshot.childrenCount } returns playerInfoRealtimeResponseList.size.toLong()
+            every { mockDataSnapshot.childrenCount } returns playerInfoRealtimeWithKeyResponseList.size.toLong()
 
-            every { mockDataSnapshot.children } returns playerInfoRealtimeResponseList.map { playerInfo ->
+            every { mockDataSnapshot.key } returns playerInfoRealtimeWithKeyResponseList[0].playerFirebaseKey
+            every { mockDataSnapshot.children } returns playerInfoRealtimeWithKeyResponseList.map { playerInfo ->
                 val mockChildSnapshot = mockk<DataSnapshot>()
-                every { mockChildSnapshot.getValue(PlayerInfoRealtimeResponse::class.java) } returns playerInfo
+                every { mockChildSnapshot.getValue(PlayerInfoRealtimeResponse::class.java) } returns playerInfo.playerInfo
                 mockChildSnapshot
             }
 
@@ -561,7 +564,7 @@ class ReadFirebaseUserInfoImplTest {
                 slot.captured.onDataChange(mockDataSnapshot)
             }
 
-            Assertions.assertEquals(playerInfoRealtimeResponseList, readFirebaseUserInfoImpl.getPlayerInfoList(accountKey = firebaseAccountKey).first())
+            Assertions.assertEquals(playerInfoRealtimeWithKeyResponseList, readFirebaseUserInfoImpl.getPlayerInfoList(accountKey = firebaseAccountKey).first())
         }
     }
 


### PR DESCRIPTION
### Trello
https://trello.com/c/4MaLDniP/143-firebase-method-to-delete-a-given-player

### Issues
- We don't have a way in Firebase to delete a given player. We should have the ability to delete a player by a passed in player entire data class when necessary.
- Currently in the create fetch call to get given player info list; we are not getting back the actual firebase key reference to identify a player as a unique instance. We need to include that in the get response for later. 

### Proposed Changes
- Introduce a function to delete a given player so long as the user passes in a `accountKey` which is unique to a given account, and a  `playerKey` which is unique to a player in a account. It will attempt to delete that player and then give back a boolean whether or not it's successful or not. 
- In the get call for getting players for firebase realtime database, include each player unique key as a response. This will then be used to save up to a Room table in order to the actual player key whenever we want to delete it via Firebase and Room.  

### TO-DO
- Introduce extension functions to update a player instance 
- Room counterpart functions. 
- Actual UI of players screen 

### Additional Info
- N/A 

### Screenshots / Videos 
- N/A 