### PR TITLE
nick: Firebase method to delete a given player

### DIFF
--- a/app/src/main/java/com/nicholas/rutherford/track/my/shot/AppModule.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/my/shot/AppModule.kt
@@ -37,6 +37,8 @@ import com.nicholas.rutherford.track.my.shot.firebase.core.delete.DeleteFirebase
 import com.nicholas.rutherford.track.my.shot.firebase.core.delete.DeleteFirebaseUserInfoImpl
 import com.nicholas.rutherford.track.my.shot.firebase.core.read.ReadFirebaseUserInfo
 import com.nicholas.rutherford.track.my.shot.firebase.core.read.ReadFirebaseUserInfoImpl
+import com.nicholas.rutherford.track.my.shot.firebase.core.update.UpdateFirebaseUserInfo
+import com.nicholas.rutherford.track.my.shot.firebase.core.update.UpdateFirebaseUserInfoImpl
 import com.nicholas.rutherford.track.my.shot.firebase.util.authentication.AuthenticationFirebase
 import com.nicholas.rutherford.track.my.shot.firebase.util.authentication.AuthenticationFirebaseImpl
 import com.nicholas.rutherford.track.my.shot.firebase.util.existinguser.ExistingUserFirebase
@@ -111,6 +113,9 @@ class AppModule {
         }
         single<ReadFirebaseUserInfo> {
             ReadFirebaseUserInfoImpl(firebaseAuth = get(), firebaseDatabase = get())
+        }
+        single<UpdateFirebaseUserInfo> {
+            UpdateFirebaseUserInfoImpl(firebaseDatabase = get())
         }
         single<DeleteFirebaseUserInfo> {
             DeleteFirebaseUserInfoImpl(firebaseDatabase = get())

--- a/firebase/core/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/core/update/UpdateFirebaseUserInfo.kt
+++ b/firebase/core/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/core/update/UpdateFirebaseUserInfo.kt
@@ -1,0 +1,8 @@
+package com.nicholas.rutherford.track.my.shot.firebase.core.update
+
+import com.nicholas.rutherford.track.my.shot.firebase.realtime.PlayerInfoRealtimeWithKeyResponse
+import kotlinx.coroutines.flow.Flow
+
+interface UpdateFirebaseUserInfo {
+    fun updatePlayer(accountKey: String, playerInfoRealtimeWithKeyResponse: PlayerInfoRealtimeWithKeyResponse): Flow<Boolean>
+}

--- a/firebase/core/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/core/update/UpdateFirebaseUserInfoImpl.kt
+++ b/firebase/core/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/core/update/UpdateFirebaseUserInfoImpl.kt
@@ -1,0 +1,40 @@
+package com.nicholas.rutherford.track.my.shot.firebase.core.update
+
+import com.google.firebase.database.FirebaseDatabase
+import com.nicholas.rutherford.track.my.shot.firebase.realtime.PlayerInfoRealtimeWithKeyResponse
+import com.nicholas.rutherford.track.my.shot.helper.constants.Constants
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import timber.log.Timber
+
+class UpdateFirebaseUserInfoImpl(private val firebaseDatabase: FirebaseDatabase) : UpdateFirebaseUserInfo {
+    override fun updatePlayer(
+        accountKey: String,
+        playerInfoRealtimeWithKeyResponse: PlayerInfoRealtimeWithKeyResponse
+    ): Flow<Boolean> {
+        val playerDataToUpdate = mapOf(
+            "firstName" to playerInfoRealtimeWithKeyResponse.playerInfo.firstName,
+            "lastName" to playerInfoRealtimeWithKeyResponse.playerInfo.lastName,
+            "imageUrl" to playerInfoRealtimeWithKeyResponse.playerInfo.imageUrl,
+            "positionValue" to playerInfoRealtimeWithKeyResponse.playerInfo.positionValue
+        )
+        return callbackFlow {
+            firebaseDatabase.getReference(Constants.USERS)
+                .child(Constants.ACCOUNT_INFO)
+                .child(accountKey)
+                .child(Constants.PLAYERS)
+                .child(playerInfoRealtimeWithKeyResponse.playerFirebaseKey)
+                .updateChildren(playerDataToUpdate)
+                .addOnCompleteListener { task ->
+                    if (task.isSuccessful) {
+                        trySend(element = true)
+                    } else {
+                        Timber.w(message = "Warning(updatePlayer) -> Was not able to update current player from given account.")
+                        trySend(element = false)
+                    }
+                }
+            awaitClose()
+        }
+    }
+}

--- a/firebase/core/src/test/java/com/nicholas/rutherford/track/my/shot/firebase/core/update/UpdateFirebaseUserInfoImplTest.kt
+++ b/firebase/core/src/test/java/com/nicholas/rutherford/track/my/shot/firebase/core/update/UpdateFirebaseUserInfoImplTest.kt
@@ -1,0 +1,112 @@
+package com.nicholas.rutherford.track.my.shot.firebase.core.update
+
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.database.FirebaseDatabase
+import com.nicholas.rutherford.track.my.shot.firebase.realtime.TestPlayerInfoRealtimeWithKeyResponse
+import com.nicholas.rutherford.track.my.shot.helper.constants.Constants
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class UpdateFirebaseUserInfoImplTest {
+
+    private lateinit var updateFirebaseUserInfoImpl: UpdateFirebaseUserInfoImpl
+
+    private val firebaseDatabase = mockk<FirebaseDatabase>(relaxed = true)
+
+    val firebaseAccountKey = "-kTE1212D"
+    val playerInfoRealtimeWithKeyResponse = TestPlayerInfoRealtimeWithKeyResponse().create()
+
+    @BeforeEach
+    fun beforeEach() {
+        updateFirebaseUserInfoImpl = UpdateFirebaseUserInfoImpl(firebaseDatabase = firebaseDatabase)
+    }
+
+    @Nested
+    inner class UpdatePlayer {
+
+        @OptIn(ExperimentalCoroutinesApi::class)
+        @Test
+        fun `when on complete listener is executed and returns isSuccessful returns true should set flow to true`() = runTest {
+            val mockTaskVoidResult = mockk<Task<Void>>()
+            val slot = slot<OnCompleteListener<Void>>()
+            val playerDataToUpdate = mapOf(
+                "firstName" to playerInfoRealtimeWithKeyResponse.playerInfo.firstName,
+                "lastName" to playerInfoRealtimeWithKeyResponse.playerInfo.lastName,
+                "imageUrl" to playerInfoRealtimeWithKeyResponse.playerInfo.imageUrl,
+                "positionValue" to playerInfoRealtimeWithKeyResponse.playerInfo.positionValue
+            )
+
+            mockkStatic(Tasks::class)
+
+            every { mockTaskVoidResult.isSuccessful } returns true
+
+            every {
+                firebaseDatabase.getReference(Constants.USERS)
+                    .child(Constants.ACCOUNT_INFO)
+                    .child(firebaseAccountKey)
+                    .child(Constants.PLAYERS)
+                    .child(playerInfoRealtimeWithKeyResponse.playerFirebaseKey)
+                    .updateChildren(playerDataToUpdate)
+                    .addOnCompleteListener(capture(slot))
+            } answers {
+                slot.captured.onComplete(mockTaskVoidResult)
+                mockTaskVoidResult
+            }
+
+            val value = updateFirebaseUserInfoImpl.updatePlayer(
+                accountKey = firebaseAccountKey,
+                playerInfoRealtimeWithKeyResponse = playerInfoRealtimeWithKeyResponse
+            ).first()
+
+            Assertions.assertEquals(true, value)
+        }
+
+        @OptIn(ExperimentalCoroutinesApi::class)
+        @Test
+        fun `when on complete listener is executed and returns isSuccessful returns false should set flow to false`() = runTest {
+            val mockTaskVoidResult = mockk<Task<Void>>()
+            val slot = slot<OnCompleteListener<Void>>()
+            val playerDataToUpdate = mapOf(
+                "firstName" to playerInfoRealtimeWithKeyResponse.playerInfo.firstName,
+                "lastName" to playerInfoRealtimeWithKeyResponse.playerInfo.lastName,
+                "imageUrl" to playerInfoRealtimeWithKeyResponse.playerInfo.imageUrl,
+                "positionValue" to playerInfoRealtimeWithKeyResponse.playerInfo.positionValue
+            )
+
+            mockkStatic(Tasks::class)
+
+            every { mockTaskVoidResult.isSuccessful } returns false
+
+            every {
+                firebaseDatabase.getReference(Constants.USERS)
+                    .child(Constants.ACCOUNT_INFO)
+                    .child(firebaseAccountKey)
+                    .child(Constants.PLAYERS)
+                    .child(playerInfoRealtimeWithKeyResponse.playerFirebaseKey)
+                    .updateChildren(playerDataToUpdate)
+                    .addOnCompleteListener(capture(slot))
+            } answers {
+                slot.captured.onComplete(mockTaskVoidResult)
+                mockTaskVoidResult
+            }
+
+            val value = updateFirebaseUserInfoImpl.updatePlayer(
+                accountKey = firebaseAccountKey,
+                playerInfoRealtimeWithKeyResponse = playerInfoRealtimeWithKeyResponse
+            ).first()
+
+            Assertions.assertEquals(false, value)
+        }
+    }
+}


### PR DESCRIPTION
### Trello
https://trello.com/c/4MaLDniP/143-firebase-method-to-delete-a-given-player

### Issues
- We don't have a way in Firebase to delete a given player. We should have the ability to delete a player by a passed in player entire data class when necessary.

### Proposed Changes
- Add a way to delete a player via Firebase when necessary. This should take in a player type in order to delete it, if the player couldn't be deleted we should include additional info like the player didn't exist; or there was a network error.

### TO-DO
- Room functions 

### Additional Info
- N/A 

### Screenshots / Videos 
- N/A 